### PR TITLE
Remove expensive calls in metrics explorer

### DIFF
--- a/public/app/plugins/datasource/prometheus/language_provider.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.ts
@@ -121,7 +121,10 @@ export default class PromQlLanguageProvider extends LanguageProvider {
 
     this.metrics = (await this.fetchLabelValues('__name__')) || [];
     this.histogramMetrics = processHistogramMetrics(this.metrics).sort();
-    return Promise.all([this.loadMetricsMetadata(), this.fetchLabels()]);
+    return Promise.all([
+      this.loadMetricsMetadata(),
+      // this.fetchLabels(), // This is an expensive call.
+    ]);
   };
 
   async loadMetricsMetadata() {

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricsLabelsSection.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricsLabelsSection.tsx
@@ -237,13 +237,8 @@ async function getMetrics(
     datasource.languageProvider.metricsMetadata = {};
   }
 
-  let metrics: string[];
-  if (query.labels.length > 0) {
-    const expr = promQueryModeller.renderLabels(query.labels);
-    metrics = (await datasource.languageProvider.getSeries(expr, true))['__name__'] ?? [];
-  } else {
-    metrics = (await datasource.languageProvider.getLabelValues('__name__')) ?? [];
-  }
+  // Ignore filters when querying metrics list for good performance.
+  let metrics = (await datasource.languageProvider.getLabelValues('__name__')) ?? [];
 
   return metrics.map((m) => ({
     value: m,


### PR DESCRIPTION
Remove two expensive calls from Grafana UI to data sources.

1. Getting list of all labels
2. Avoid getSeries API to query metric names