### PR TITLE
Use Labels API for aggregation labels dropdown

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/components/LabelParamEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/LabelParamEditor.tsx
@@ -51,7 +51,7 @@ async function loadGroupByLabels(query: PromVisualQuery, datasource: DataSourceA
   }
 
   const expr = promQueryModeller.renderLabels(labels);
-  const result = await datasource.languageProvider.fetchSeriesLabels(expr);
+  const result = await datasource.languageProvider.fetchSeriesLabelsMatch(expr);
 
   return Object.keys(result).map((x) => ({
     label: x,


### PR DESCRIPTION
Use labels API instead of Series API for aggregation labels 
drop down.