### PR TITLE
Enrich oodle insight event with additional details

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -189,6 +189,7 @@ Experimental features might be changed or removed without prior notice.
 | `dashboardRestore`                          | Enables deleted dashboard restore feature                                                                                                                                                                                                                                         |
 | `alertingCentralAlertHistory`               | Enables the new central alert history.                                                                                                                                                                                                                                            |
 | `azureMonitorPrometheusExemplars`           | Allows configuration of Azure Monitor as a data source that can provide Prometheus exemplars                                                                                                                                                                                      |
+| `oodleInsight`                              | Enables Oodle Insight for Grafana                                                                                                                                                                                                                                                 |
 
 ## Development feature toggles
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -192,4 +192,5 @@ export interface FeatureToggles {
   alertingCentralAlertHistory?: boolean;
   pluginProxyPreserveTrailingSlash?: boolean;
   azureMonitorPrometheusExemplars?: boolean;
+  oodleInsight?: boolean;
 }

--- a/pkg/services/featuremgmt/codeowners.go
+++ b/pkg/services/featuremgmt/codeowners.go
@@ -28,4 +28,5 @@ const (
 	enterpriseDatasourcesSquad                  codeowner = "@grafana/enterprise-datasources"
 	grafanaSharingSquad                         codeowner = "@grafana/sharing-squad"
 	grafanaDatabasesFrontend                    codeowner = "@grafana/databases-frontend"
+	grafanaOodleSquad                           codeowner = "@grafana/oodle-squad"
 )

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1302,6 +1302,13 @@ var (
 			Stage:       FeatureStageExperimental,
 			Owner:       grafanaPartnerPluginsSquad,
 		},
+		{
+			Name:        "oodleInsight",
+			Description: "Enables Oodle Insight for Grafana",
+			Stage:       FeatureStageExperimental,
+			Owner:       grafanaOodleSquad,
+			Expression:  "false",
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -173,3 +173,4 @@ preserveDashboardStateWhenNavigating,experimental,@grafana/dashboards-squad,fals
 alertingCentralAlertHistory,experimental,@grafana/alerting-squad,false,false,true
 pluginProxyPreserveTrailingSlash,GA,@grafana/plugins-platform-backend,false,false,false
 azureMonitorPrometheusExemplars,experimental,@grafana/partner-datasources,false,false,false
+oodleInsight,experimental,@grafana/oodle-squad,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -702,4 +702,8 @@ const (
 	// FlagAzureMonitorPrometheusExemplars
 	// Allows configuration of Azure Monitor as a data source that can provide Prometheus exemplars
 	FlagAzureMonitorPrometheusExemplars = "azureMonitorPrometheusExemplars"
+
+	// FlagOodleInsight
+	// Enables Oodle Insight for Grafana
+	FlagOodleInsight = "oodleInsight"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2250,6 +2250,18 @@
         "stage": "experimental",
         "codeowner": "@grafana/partner-datasources"
       }
+    },
+    {
+      "metadata": {
+        "name": "oodleInsight",
+        "resourceVersion": "1721950968536",
+        "creationTimestamp": "2024-07-25T23:42:48Z"
+      },
+      "spec": {
+        "description": "Enables Oodle Insight for Grafana",
+        "stage": "experimental",
+        "codeowner": "@grafana/oodle-squad"
+      }
     }
   ]
 }

--- a/public/app/features/query/components/QueryGroup.tsx
+++ b/public/app/features/query/components/QueryGroup.tsx
@@ -19,7 +19,6 @@ import { PluginHelp } from 'app/core/components/PluginHelp/PluginHelp';
 import config from 'app/core/config';
 import { backendSrv } from 'app/core/services/backend_srv';
 import { addQuery, queryIsEmpty } from 'app/core/utils/query';
-import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { DataSourceModal } from 'app/features/datasources/components/picker/DataSourceModal';
 import { DataSourcePicker } from 'app/features/datasources/components/picker/DataSourcePicker';
 import { dataSource as expressionDatasource } from 'app/features/expressions/ExpressionDatasource';
@@ -398,21 +397,6 @@ export function QueryGroupTopSection({
   const styles = getStyles();
   const [isHelpOpen, setIsHelpOpen] = useState(false);
 
-  // Custom type
-  interface SendDataToParentProps {
-    type: string;
-    payload: {
-      eventType: string;
-      source: string;
-      value: any;
-    };
-  }
-
-  // Custom function
-  function sendEventToParent(data: SendDataToParentProps) {
-    window.parent.postMessage(data, '*');
-  }
-
   return (
     <>
       <div data-testid={selectors.components.QueryTab.queryGroupTopSection}>
@@ -449,47 +433,6 @@ export function QueryGroupTopSection({
                     onOptionsChange?.(opts);
                   }}
                 />
-              </div>
-              <div className={styles.dataSourceRowItem}>
-                <Button
-                  style={{border: 0, padding: 0}}
-                  variant="secondary"
-                  fill="outline"
-                  type="button"
-                  data-testid="send-query-button"
-                  tooltip={"Oodle insight"}
-                  tooltipPlacement="top"
-                  onClick={() => {
-                    const dashboard = getDashboardSrv().getCurrent() ?? null;   
-                    const panelData = dashboard?.panels.find(panel => panel.id === data?.request?.panelId)                
-
-                    const expressionData = {
-                      dashboardTitle: dashboard ? dashboard?.title : "",
-                      panelTitle: dashboard ? dashboard?.panelInEdit?.title : "",
-                      panelId: data.request?.panelId,
-                      panelKey: dashboard ? dashboard?.panelInEdit?.key : "",
-                      expressionData: data.request?.targets,
-                      dashboardTime: data.timeRange,
-                      unit: panelData?.fieldConfig?.defaults?.unit
-                    }
-                    
-                    sendEventToParent({
-                      type: 'message',
-                      payload: {
-                        source: 'oodle-grafana',
-                        eventType: 'sendQuery',
-                        value: JSON.parse(JSON.stringify(expressionData)),
-                      },
-                    });
-                  }}
-                >
-                  <img
-                    src="https://imagedelivery.net/oP5rEbdkySYwiZY4N9HGRw/053db276-ec3f-470a-af99-23970c325500/public"
-                    alt="Insight icon"
-                    data-testid="insight-icon"
-                    style={{ height: '32px' }}
-                  />
-                </Button>
               </div>
               {onOpenQueryInspector && (
                 <div className={styles.dataSourceRowItem}>


### PR DESCRIPTION
Closes D-110

# Description
Enrich oodle insight event to parent with the following details
1. panelID
2. dashboardUID
3. interpolated query expression

Add a feature toggle for oodle insight and disable it by default.

Testing
1. Deployed to dev. Tested with and without enabling feature toggle.