### PR TITLE
Increase maxParallelRequests  size in grafana frontend

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -31,6 +31,9 @@ provisioning = conf/provisioning
 # Protocol (http, https, h2, socket)
 protocol = http
 
+# The maximum number of concurrent HTTP requests
+http1_max_parallel_requests = 30
+
 # Minimum TLS version allowed. By default, this value is empty. Accepted values are: TLS1.2, TLS1.3. If nothing is set TLS1.2 would be taken
 min_tls_version = ""
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -31,6 +31,9 @@
 # Protocol (http, https, h2, socket)
 ;protocol = http
 
+# The maximum number of concurrent HTTP requests
+;http1_max_parallel_requests = 30
+
 # This is the minimum TLS version allowed. By default, this value is empty. Accepted values are: TLS1.2, TLS1.3. If nothing is set TLS1.2 would be taken
 ;min_tls_version = ""
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -193,6 +193,10 @@ Folder that contains [provisioning]({{< relref "../../administration/provisionin
 
 `http`,`https`,`h2` or `socket`
 
+### http1_max_parallel_requests
+The maximum number of parallel requests that can be handled by the HTTP/1.1 server. Default is `30`.
+30
+
 ### min_tls_version
 
 The TLS Handshake requires a minimum TLS version. The available options are TLS1.2 and TLS1.3.

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -203,6 +203,7 @@ export interface GrafanaConfig {
   featureToggles: FeatureToggles;
   licenseInfo: LicenseInfo;
   http2Enabled: boolean;
+  http1MaxParallelRequests: number;
   dateFormats?: SystemDateFormatSettings;
   grafanaJavascriptAgent: GrafanaJavascriptAgentConfig;
   customTheme?: any;

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -108,6 +108,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   secretsManagerPluginEnabled = false;
   supportBundlesEnabled = false;
   http2Enabled = false;
+  http1MaxParallelRequests = 30;
   dateFormats?: SystemDateFormatSettings;
   grafanaJavascriptAgent = {
     enabled: false,

--- a/pkg/api/dtos/frontend_settings.go
+++ b/pkg/api/dtos/frontend_settings.go
@@ -220,6 +220,7 @@ type FrontendSettingsDTO struct {
 	RendererDefaultImageScale        float64                        `json:"rendererDefaultImageScale"`
 	SecretsManagerPluginEnabled      bool                           `json:"secretsManagerPluginEnabled"`
 	Http2Enabled                     bool                           `json:"http2Enabled"`
+	Http1MaxParallelRequests         int                            `json:"http1MaxParallelRequests"`
 	GrafanaJavascriptAgent           setting.GrafanaJavascriptAgent `json:"grafanaJavascriptAgent"`
 	PluginCatalogURL                 string                         `json:"pluginCatalogURL"`
 	PluginAdminEnabled               bool                           `json:"pluginAdminEnabled"`

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -258,6 +258,7 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 		RendererDefaultImageScale:        hs.Cfg.RendererDefaultImageScale,
 		SecretsManagerPluginEnabled:      secretsManagerPluginEnabled,
 		Http2Enabled:                     hs.Cfg.Protocol == setting.HTTP2Scheme,
+		Http1MaxParallelRequests:         hs.Cfg.HTTP1MaxParallelRequests,
 		GrafanaJavascriptAgent:           hs.Cfg.GrafanaJavascriptAgent,
 		PluginCatalogURL:                 hs.Cfg.PluginCatalogURL,
 		PluginAdminEnabled:               hs.Cfg.PluginAdminEnabled,

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -91,28 +91,29 @@ type Cfg struct {
 	appliedEnvOverrides          []string
 
 	// HTTP Server Settings
-	CertFile          string
-	KeyFile           string
-	CertWatchInterval time.Duration
-	HTTPAddr          string
-	HTTPPort          string
-	Env               string
-	AppURL            string
-	AppSubURL         string
-	InstanceName      string
-	ServeFromSubPath  bool
-	StaticRootPath    string
-	Protocol          Scheme
-	SocketGid         int
-	SocketMode        int
-	SocketPath        string
-	RouterLogging     bool
-	Domain            string
-	CDNRootURL        *url.URL
-	ReadTimeout       time.Duration
-	EnableGzip        bool
-	EnforceDomain     bool
-	MinTLSVersion     string
+	CertFile                 string
+	KeyFile                  string
+	CertWatchInterval        time.Duration
+	HTTPAddr                 string
+	HTTPPort                 string
+	Env                      string
+	AppURL                   string
+	AppSubURL                string
+	InstanceName             string
+	ServeFromSubPath         bool
+	StaticRootPath           string
+	Protocol                 Scheme
+	HTTP1MaxParallelRequests int
+	SocketGid                int
+	SocketMode               int
+	SocketPath               string
+	RouterLogging            bool
+	Domain                   string
+	CDNRootURL               *url.URL
+	ReadTimeout              time.Duration
+	EnableGzip               bool
+	EnforceDomain            bool
+	MinTLSVersion            string
 
 	// Security settings
 	SecretKey             string
@@ -1871,6 +1872,8 @@ func (cfg *Cfg) readServerSettings(iniFile *ini.File) error {
 		cfg.SocketMode = server.Key("socket_mode").MustInt(0660)
 		cfg.SocketPath = server.Key("socket").String()
 	}
+
+	cfg.HTTP1MaxParallelRequests = server.Key("http1_max_parallel_requests").MustInt(30)
 
 	cfg.MinTLSVersion = valueAsString(server, "min_tls_version", "TLS1.2")
 	if cfg.MinTLSVersion == "TLS1.0" || cfg.MinTLSVersion == "TLS1.1" {

--- a/public/app/core/services/FetchQueueWorker.ts
+++ b/public/app/core/services/FetchQueueWorker.ts
@@ -14,8 +14,7 @@ interface WorkerEntry {
 
 export class FetchQueueWorker {
   constructor(fetchQueue: FetchQueue, responseQueue: ResponseQueue, config: GrafanaBootConfig) {
-    const maxParallelRequests = config?.http2Enabled ? 1000 : 5; // for tests that don't mock GrafanaBootConfig the config param will be undefined
-
+    const maxParallelRequests = config?.http2Enabled ? 1000 : config?.http1MaxParallelRequests; // for tests that don't mock GrafanaBootConfig the config param will be undefined
     // This will create an implicit live subscription for as long as this class lives.
     // But as FetchQueueWorker is used by the singleton backendSrv that also lives for as long as Grafana app lives
     // I think this ok. We could add some disposable pattern later if the need arises.


### PR DESCRIPTION
Increasing the max parallel request size in grafana frontend. Making it a config with default value 30.