### PR TITLE
Disable search bar for play.oodle.ai

### DIFF
--- a/public/app/core/components/AppChrome/TopBar/TopSearchBar.tsx
+++ b/public/app/core/components/AppChrome/TopBar/TopSearchBar.tsx
@@ -46,7 +46,11 @@ export const TopSearchBar = React.memo(function TopSearchBar() {
       </TopSearchBarSection> */}
 
       <TopSearchBarSection>
-        <TopSearchBarCommandPaletteTrigger />
+      {
+        window.location.hostname !== 'play.oodle.ai' && (
+            <TopSearchBarCommandPaletteTrigger />
+        )
+      }
       </TopSearchBarSection>
 
       <TopSearchBarSection align="right">

--- a/public/app/features/commandPalette/CommandPalette.tsx
+++ b/public/app/features/commandPalette/CommandPalette.tsx
@@ -51,7 +51,7 @@ export function CommandPalette() {
     showing && reportInteraction('command_palette_opened');
   }, [showing]);
 
-  return actions.length > 0 ? (
+  return (actions.length > 0 && window.location.hostname !== 'play.oodle.ai') ? (
     <KBarPortal>
       <KBarPositioner className={styles.positioner}>
         <KBarAnimator className={styles.animator}>


### PR DESCRIPTION
play.oodle.ai is where the users from Show HN
will get to explore a pre-created Oodle instance
in a read-only manner by auto-logging-in as a
hard-coded user.

Even a non-editor user in Grafana can set dark
mode for Grafana UI, which can make the Oodle UI
ugly. To make it difficult to accidentally do so,
and access any other similar settings, we disable
the search menu on play.oodle.ai.

Test:
Changed `play` to `app-dev` and deployed to `dev`.
Confirmed that the bar doesn't show and `cmd+k`
doesn't work. Changed back to `play` and confirmed
that the bar shows and shortcut works.