### PR TITLE
Fix Failed to Fetch

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -535,7 +535,9 @@ func (hs *HTTPServer) registerRoutes() {
 			annotationsRoute.Get("/tags", authorize(ac.EvalPermission(ac.ActionAnnotationsRead)), routing.Wrap(hs.GetAnnotationTags))
 		})
 
-		apiRoute.Post("/frontend-metrics", routing.Wrap(hs.PostFrontendMetrics))
+		// /fronten-metrics is blocked by some ad blockers and it can show
+		// 'Failed to Fetch' error in the UI if this API fails.
+		apiRoute.Post("/fe-metrics-endpoint", routing.Wrap(hs.PostFrontendMetrics))
 
 		apiRoute.Group("/live", func(liveRoute routing.RouteRegister) {
 			// the channel path is in the name

--- a/public/app/core/services/echo/backends/PerformanceBackend.ts
+++ b/public/app/core/services/echo/backends/PerformanceBackend.ts
@@ -32,7 +32,7 @@ export class PerformanceBackend implements EchoBackend<PerformanceEvent, Perform
       return;
     }
 
-    backendSrv.post('/api/frontend-metrics', {
+    backendSrv.post('/api/fe-metrics-endpoint', {
       events: this.buffer,
     });
 


### PR DESCRIPTION
frontend-metrics is blocked by some ad-blockers
which can cause some errors to be shown on the UI.

Rename the endpoint to an unblocked path.