### PR TITLE
D 756 syntax highlighting for px funcs

### DIFF
--- a/packages/grafana-prometheus/src/components/monaco-query-field/promql.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/promql.ts
@@ -103,6 +103,9 @@ const functions = [
   'minute',
   'month',
   'predict_linear',
+  'pdelta',
+  'pincrease',
+  'prate',
   'rate',
   'resets',
   'round',
@@ -113,6 +116,9 @@ const functions = [
   'time',
   'timestamp',
   'vector',
+  'xdelta',
+  'xincrease',
+  'xrate',
   'year',
 ];
 // PromQL specific functions: Aggregations over time


### PR DESCRIPTION
Closes D-756

In https://github.com/oodle-ai/oodle-thanos/pull/67 we added
`p{rate,delta,increase}` functions. Also, we have
long been supporting `x{rate,delta,increase}` functions.

With this change, now the Grafana UI correctly recognizes them
while highlighting the PromQL syntax.

TODO: actually test this and add screenshots.