### PR TITLE
Remove out of range warning

### DIFF
--- a/public/app/plugins/panel/graph/module.ts
+++ b/public/app/plugins/panel/graph/module.ts
@@ -250,32 +250,33 @@ export class GraphCtrl extends MetricsPanelCtrl {
       };
     }
 
-    // If any data is in range, do not return an error
-    for (const series of this.seriesList) {
-      if (!series.isOutsideRange) {
-        return undefined;
-      }
-    }
-
-    // All data is outside the time range
-    const dataWarning: DataWarning = {
-      title: 'Data outside time range',
-      tip: 'Can be caused by timezone mismatch or missing time filter in query',
-    };
-
-    const range = getDataTimeRange(this.dataList);
-
-    if (range) {
-      dataWarning.actionText = 'Zoom to data';
-      dataWarning.action = () => {
-        locationService.partial({
-          from: range.from,
-          to: range.to,
-        });
-      };
-    }
-
-    return dataWarning;
+    return undefined;
+    // // If any data is in range, do not return an error
+    // for (const series of this.seriesList) {
+    //   if (!series.isOutsideRange) {
+    //     return undefined;
+    //   }
+    // }
+    //
+    // // All data is outside the time range
+    // const dataWarning: DataWarning = {
+    //   title: 'Data outside time range',
+    //   tip: 'Can be caused by timezone mismatch or missing time filter in query',
+    // };
+    //
+    // const range = getDataTimeRange(this.dataList);
+    //
+    // if (range) {
+    //   dataWarning.actionText = 'Zoom to data';
+    //   dataWarning.action = () => {
+    //     locationService.partial({
+    //       from: range.from,
+    //       to: range.to,
+    //     });
+    //   };
+    // }
+    //
+    // return dataWarning;
   }
 
   onRender() {

--- a/public/app/plugins/panel/timeseries/plugins/OutsideRangePlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/OutsideRangePlugin.tsx
@@ -54,6 +54,9 @@ export const OutsideRangePlugin = ({ config, onChangeTimeRange }: ThresholdContr
     return null;
   }
 
+  // Disable OutsideRangePlugin.
+  return null;
+
   // (StartA <= EndB) and (EndA >= StartB)
   if (first <= toX && last >= fromX) {
     return null;


### PR DESCRIPTION
Events use labels as timestamp which can be slightly out of range.

Hide this warning.