### PR TITLE
Use expand view for wide rows

### DIFF
--- a/public/app/features/explore/PrometheusListView/RawListContainer.tsx
+++ b/public/app/features/explore/PrometheusListView/RawListContainer.tsx
@@ -53,6 +53,7 @@ const styles = {
 
 const mobileWidthThreshold = 480;
 const numberOfColumnsBeforeExpandedViewIsDefault = 2;
+const numTotalColumnsBeforeExpandedViewIsDefault = 5;
 
 /**
  * The container that provides the virtualized list to the child components
@@ -65,10 +66,13 @@ const RawListContainer = (props: RawListContainerProps) => {
   const listRef = useRef<List | null>(null);
 
   const valueLabels = dataFrame.fields.filter((field) => field.name.includes('Value'));
+  const totalLabels = dataFrame.fields.length;
   const items = getRawPrometheusListItemsFromDataFrame(dataFrame);
   const { width } = useWindowSize();
   const [isExpandedView, setIsExpandedView] = useState(
-    width <= mobileWidthThreshold || valueLabels.length > numberOfColumnsBeforeExpandedViewIsDefault
+    width <= mobileWidthThreshold ||
+    valueLabels.length > numberOfColumnsBeforeExpandedViewIsDefault ||
+    totalLabels > numTotalColumnsBeforeExpandedViewIsDefault
   );
 
   const onContentClick = () => {

--- a/public/app/plugins/panel/graph/module.ts
+++ b/public/app/plugins/panel/graph/module.ts
@@ -9,7 +9,7 @@ import { auto } from 'angular';
 import { defaults, find, without } from 'lodash';
 
 import { DataFrame, FieldConfigProperty, PanelEvents, PanelPlugin } from '@grafana/data';
-import { locationService } from '@grafana/runtime';
+// import { locationService } from '@grafana/runtime';
 import { MetricsPanelCtrl } from 'app/angular/panel/metrics_panel_ctrl';
 import config from 'app/core/config';
 import TimeSeries from 'app/core/time_series2';
@@ -29,7 +29,7 @@ import { axesEditorComponent } from './axes_editor';
 import { DataProcessor } from './data_processor';
 import template from './template';
 import { DataWarning, GraphFieldConfig, GraphPanelOptions } from './types';
-import { getDataTimeRange } from './utils';
+// import { getDataTimeRange } from './utils';
 
 export class GraphCtrl extends MetricsPanelCtrl {
   static template = template;


### PR DESCRIPTION
Set expand view on by default if result has
a large number of labels.

This makes it easier to read and view the whole row.