### PR TITLE
Add a new PromQL editor page

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -447,6 +447,7 @@ export interface QueryEditorProps<
   history?: Array<HistoryItem<TQuery>>;
   queries?: DataQuery[];
   app?: CoreApp;
+  queryBuilderOnly?: boolean;
 }
 
 // TODO: not really needed but used as type in some data sources and in DataQueryRequest

--- a/packages/grafana-prometheus/src/querybuilder/components/PromQueryEditorSelector.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/PromQueryEditorSelector.tsx
@@ -46,6 +46,7 @@ export const PromQueryEditorSelector = memo<Props>((props) => {
     onAddQuery,
     datasource: { defaultEditor },
     queries,
+    queryBuilderOnly,
   } = props;
 
   const [parseModalOpen, setParseModalOpen] = useState(false);
@@ -75,6 +76,10 @@ export const PromQueryEditorSelector = memo<Props>((props) => {
         }
       }
       changeEditorMode(query, newMetricEditorMode, onChange);
+      if (queryBuilderOnly) {
+        // Trigger onRunQuery to change URL to reflect the new editor mode.
+        onRunQuery();
+      }
     },
     [onChange, query, app]
   );
@@ -160,7 +165,7 @@ export const PromQueryEditorSelector = memo<Props>((props) => {
             showExplain={explain}
           />
         )}
-        <PromQueryBuilderOptions query={query} app={props.app} onChange={onChange} onRunQuery={onRunQuery} />
+        {!queryBuilderOnly && <PromQueryBuilderOptions query={query} app={props.app} onChange={onChange} onRunQuery={onRunQuery} />}
       </EditorRows>
     </>
   );

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -177,6 +177,7 @@ func (hs *HTTPServer) registerRoutes() {
 	}
 
 	r.Get("/explore", authorize(ac.EvalPermission(ac.ActionDatasourcesExplore)), hs.Index)
+	r.Get("/promql-editor", authorize(ac.EvalPermission(ac.ActionDatasourcesExplore)), hs.Index)
 
 	r.Get("/playlists/", reqSignedIn, hs.Index)
 	r.Get("/playlists/*", reqSignedIn, hs.Index)

--- a/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
+++ b/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
@@ -24,6 +24,7 @@ export interface QueryOperationRowProps {
   collapsable?: boolean;
   disabled?: boolean;
   expanderMessages?: ExpanderMessages;
+  queryBuilderOnly?: boolean;
 }
 
 export type QueryOperationRowRenderProp = ((props: QueryOperationRowRenderProps) => React.ReactNode) | React.ReactNode;
@@ -48,6 +49,7 @@ export function QueryOperationRow({
   index,
   id,
   expanderMessages,
+  queryBuilderOnly,
 }: QueryOperationRowProps) {
   const [isContentVisible, setIsContentVisible] = useState(isOpen !== undefined ? isOpen : true);
   const styles = useStyles2(getQueryOperationRowStyles);
@@ -114,7 +116,7 @@ export function QueryOperationRow({
             <>
               <div ref={provided.innerRef} className={styles.wrapper} {...provided.draggableProps}>
                 <div>
-                  <QueryOperationRowHeader
+                  {!queryBuilderOnly && <QueryOperationRowHeader
                     id={id}
                     actionsElement={actionsElement}
                     disabled={disabled}
@@ -127,7 +129,7 @@ export function QueryOperationRow({
                     reportDragMousePosition={reportDragMousePosition}
                     title={title}
                     expanderMessages={expanderMessages}
-                  />
+                  />}
                 </div>
                 {isContentVisible && <div className={styles.content}>{children}</div>}
               </div>
@@ -140,7 +142,7 @@ export function QueryOperationRow({
 
   return (
     <div className={styles.wrapper}>
-      <QueryOperationRowHeader
+      {!queryBuilderOnly && <QueryOperationRowHeader
         id={id}
         actionsElement={actionsElement}
         disabled={disabled}
@@ -152,7 +154,7 @@ export function QueryOperationRow({
         reportDragMousePosition={reportDragMousePosition}
         title={title}
         expanderMessages={expanderMessages}
-      />
+      />}
       {isContentVisible && <div className={styles.content}>{children}</div>}
     </div>
   );

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -107,6 +107,7 @@ export interface ExploreProps extends Themeable2 {
   eventBus: EventBus;
   setShowQueryInspector: (value: boolean) => void;
   showQueryInspector: boolean;
+  queryBuilderOnly?: boolean;
 }
 
 interface ExploreState {
@@ -534,8 +535,13 @@ export class Explore extends PureComponent<Props, ExploreState> {
       correlationEditorHelperData,
       showQueryInspector,
       setShowQueryInspector,
+      queryBuilderOnly,
     } = this.props;
-    const { contentOutlineVisible } = this.state;
+    let { contentOutlineVisible } = this.state;
+    if (queryBuilderOnly) {
+      contentOutlineVisible = false;
+    }
+
     const styles = getStyles(theme);
     const showPanels = queryResponse && queryResponse.state !== LoadingState.NotStarted;
     const richHistoryRowButtonHidden = !supportedFeatures().queryHistoryAvailable;
@@ -566,6 +572,7 @@ export class Explore extends PureComponent<Props, ExploreState> {
           onChangeTime={this.onChangeTime}
           onContentOutlineToogle={this.onContentOutlineToogle}
           isContentOutlineOpen={contentOutlineVisible}
+          queryBuilderOnly={queryBuilderOnly}
         />
         <div
           style={{
@@ -589,8 +596,8 @@ export class Explore extends PureComponent<Props, ExploreState> {
                     <ContentOutlineItem panelId="Queries" title="Queries" icon="arrow" mergeSingleChild={true}>
                       <PanelContainer className={styles.queryContainer}>
                         {correlationsBox}
-                        <QueryRows exploreId={exploreId} />
-                        <SecondaryActions
+                        <QueryRows exploreId={exploreId} queryBuilderOnly={queryBuilderOnly} />
+                        {!queryBuilderOnly && <SecondaryActions
                           // do not allow people to add queries with potentially different datasources in correlations editor mode
                           addQueryRowButtonDisabled={
                             isLive || (isCorrelationsEditorMode && datasourceInstance.meta.mixed)
@@ -602,7 +609,7 @@ export class Explore extends PureComponent<Props, ExploreState> {
                           queryInspectorButtonActive={showQueryInspector}
                           onClickAddQueryRowButton={this.onClickAddQueryRowButton}
                           onClickQueryInspectorButton={() => setShowQueryInspector(!showQueryInspector)}
-                        />
+                        />}
                         <ResponseErrorContainer exploreId={exploreId} />
                       </PanelContainer>
                     </ContentOutlineItem>
@@ -615,7 +622,7 @@ export class Explore extends PureComponent<Props, ExploreState> {
                         return (
                           <main className={cx(styles.exploreMain)} style={{ width }}>
                             <ErrorBoundaryAlert>
-                              {showPanels && (
+                              {!queryBuilderOnly && showPanels && (
                                 <>
                                   {showMetrics && graphResult && (
                                     <ErrorBoundaryAlert>{this.renderGraphPanel(width)}</ErrorBoundaryAlert>

--- a/public/app/features/explore/ExplorePaneContainer.tsx
+++ b/public/app/features/explore/ExplorePaneContainer.tsx
@@ -22,6 +22,7 @@ const containerStyles = css({
 
 interface Props {
   exploreId: string;
+  queryBuilderOnly?: boolean;
 }
 
 /*
@@ -33,7 +34,7 @@ interface Props {
 
   You can read more about this issue here: https://react-redux.js.org/api/hooks#stale-props-and-zombie-children
 */
-function ExplorePaneContainerUnconnected({ exploreId }: Props) {
+function ExplorePaneContainerUnconnected({ exploreId, queryBuilderOnly = false }: Props) {
   useStopQueries(exploreId);
   const eventBus = useRef(new EventBusSrv());
   const ref = useRef(null);
@@ -52,6 +53,7 @@ function ExplorePaneContainerUnconnected({ exploreId }: Props) {
           eventBus={eventBus.current}
           showQueryInspector={showQueryInspector}
           setShowQueryInspector={setShowQueryInspector}
+          queryBuilderOnly={queryBuilderOnly}
         />
         {showQueryInspector && (
           <ExploreQueryInspector

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -62,9 +62,10 @@ interface Props {
   onChangeTime: (range: RawTimeRange, changedByScanner?: boolean) => void;
   onContentOutlineToogle: () => void;
   isContentOutlineOpen: boolean;
+  queryBuilderOnly?: boolean;
 }
 
-export function ExploreToolbar({ exploreId, onChangeTime, onContentOutlineToogle, isContentOutlineOpen }: Props) {
+export function ExploreToolbar({ exploreId, onChangeTime, onContentOutlineToogle, isContentOutlineOpen, queryBuilderOnly }: Props) {
   const dispatch = useDispatch();
   const splitted = useSelector(isSplit);
   const styles = useStyles2(getStyles, splitted);
@@ -206,8 +207,8 @@ export function ExploreToolbar({ exploreId, onChangeTime, onContentOutlineToogle
 
   return (
     <div>
-      {refreshInterval && <SetInterval func={onRunQuery} interval={refreshInterval} loading={loading} />}
-      {!isSingleTopNav && (
+      {!queryBuilderOnly && refreshInterval && <SetInterval func={onRunQuery} interval={refreshInterval} loading={loading} />}
+      {!queryBuilderOnly && !isSingleTopNav && (
         <div>
           <AppChromeUpdate actions={navBarActions} />
         </div>
@@ -215,7 +216,7 @@ export function ExploreToolbar({ exploreId, onChangeTime, onContentOutlineToogle
       <PageToolbar
         aria-label={t('explore.toolbar.aria-label', 'Explore toolbar')}
         leftItems={[
-          <ToolbarButton
+          !queryBuilderOnly && <ToolbarButton
             key="content-outline"
             variant="canvas"
             tooltip="Content outline"
@@ -228,7 +229,7 @@ export function ExploreToolbar({ exploreId, onChangeTime, onContentOutlineToogle
           >
             Outline
           </ToolbarButton>,
-          <DataSourcePicker
+          !queryBuilderOnly && <DataSourcePicker
             key={`${exploreId}-ds-picker`}
             mixed={!isCorrelationsEditorMode}
             onChange={onChangeDatasource}
@@ -241,8 +242,8 @@ export function ExploreToolbar({ exploreId, onChangeTime, onContentOutlineToogle
         forceShowLeftItems
       >
         {[
-          <QueriesDrawerDropdown key="queryLibrary" variant={splitted ? 'compact' : 'full'} />,
-          !splitted ? (
+          !queryBuilderOnly && <QueriesDrawerDropdown key="queryLibrary" variant={splitted ? 'compact' : 'full'} />,
+          !queryBuilderOnly && !splitted ? (
             <ToolbarButton
               variant="canvas"
               key="split"
@@ -254,7 +255,7 @@ export function ExploreToolbar({ exploreId, onChangeTime, onContentOutlineToogle
               <Trans i18nKey="explore.toolbar.split-title">Split</Trans>
             </ToolbarButton>
           ) : (
-            <ButtonGroup key="split-controls">
+            !queryBuilderOnly && <ButtonGroup key="split-controls">
               <ToolbarButton
                 variant="canvas"
                 tooltip={
@@ -277,7 +278,7 @@ export function ExploreToolbar({ exploreId, onChangeTime, onContentOutlineToogle
               </ToolbarButton>
             </ButtonGroup>
           ),
-          <ToolbarExtensionPoint key="toolbar-extension-point" exploreId={exploreId} timeZone={timeZone} />,
+          !queryBuilderOnly && <ToolbarExtensionPoint key="toolbar-extension-point" exploreId={exploreId} timeZone={timeZone} />,
           !isLive && (
             <ExploreTimeControls
               key="timeControls"

--- a/public/app/features/explore/PromqlEditorPage.tsx
+++ b/public/app/features/explore/PromqlEditorPage.tsx
@@ -1,0 +1,134 @@
+import { css, cx } from '@emotion/css';
+import { useEffect } from 'react';
+
+import { CoreApp, GrafanaTheme2 } from '@grafana/data';
+import { config } from '@grafana/runtime';
+import { ErrorBoundaryAlert, useStyles2, useTheme2 } from '@grafana/ui';
+import { QueryOperationAction } from 'app/core/components/QueryOperationRow/QueryOperationAction';
+import { SplitPaneWrapper } from 'app/core/components/SplitPaneWrapper/SplitPaneWrapper';
+import { useGrafana } from 'app/core/context/GrafanaContext';
+import { useNavModel } from 'app/core/hooks/useNavModel';
+import { t } from 'app/core/internationalization';
+import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
+import { useSelector } from 'app/types';
+import { ExploreQueryParams } from 'app/types/explore';
+
+import { RowActionComponents } from '../query/components/QueryActionComponent';
+
+import { ExplorePaneContainer } from './ExplorePaneContainer';
+import { QueriesDrawerContextProvider } from './QueriesDrawer/QueriesDrawerContext';
+import { useExplorePageTitle } from './hooks/useExplorePageTitle';
+import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
+import { useSplitSizeUpdater } from './hooks/useSplitSizeUpdater';
+import { useStateSync } from './hooks/useStateSync';
+import { useTimeSrvFix } from './hooks/useTimeSrvFix';
+import { isSplit, selectCorrelationDetails, selectPanesEntries } from './state/selectors';
+
+const MIN_PANE_WIDTH = 200;
+const QUERY_LIBRARY_ACTION_KEY = 'queryLibraryAction';
+
+export default function PromqlEditorPage(props: GrafanaRouteComponentProps<{}, ExploreQueryParams>) {
+  return (
+    <QueriesDrawerContextProvider>
+      <ExplorePageContent {...props} />
+    </QueriesDrawerContextProvider>
+  );
+}
+
+function ExplorePageContent(props: GrafanaRouteComponentProps<{}, ExploreQueryParams>) {
+  const styles = useStyles2(getStyles);
+  const theme = useTheme2();
+  useTimeSrvFix();
+  useStateSync(props.queryParams);
+  // We want  to set the title according to the URL and not to the state because the URL itself may lag
+  // (due to how useStateSync above works) by a few milliseconds.
+  // When a URL is pushed to the history, the browser also saves the title of the page and
+  // if we were to update the URL on state change, the title would not match the URL.
+  // Ultimately the URL is the single source of truth from which state is derived, the page title is not different
+  useExplorePageTitle(props.queryParams);
+  const { chrome } = useGrafana();
+  const navModel = useNavModel('explore');
+  const { updateSplitSize, widthCalc } = useSplitSizeUpdater(MIN_PANE_WIDTH);
+
+  const panes = useSelector(selectPanesEntries);
+  const hasSplit = useSelector(isSplit);
+  const correlationDetails = useSelector(selectCorrelationDetails);
+  const showCorrelationEditorBar = config.featureToggles.correlations && (correlationDetails?.editorMode || false);
+  // const [setQueryToAdd] = useState<DataQuery | undefined>();
+
+  useEffect(() => {
+    //This is needed for breadcrumbs and topnav.
+    //We should probably abstract this out at some point
+    chrome.update({
+      sectionNav: navModel,
+    });
+  }, [chrome, navModel]);
+
+  useEffect(() => {
+    const hasQueryLibrary = config.featureToggles.queryLibrary || false;
+    if (hasQueryLibrary) {
+      RowActionComponents.addKeyedExtraRenderAction(QUERY_LIBRARY_ACTION_KEY, {
+        scope: CoreApp.Explore,
+        queryActionComponent: (props) => (
+          <QueryOperationAction
+            key={props.key}
+            title={t('query-operation.header.save-to-query-library', 'Save to query library')}
+            icon="save"
+            onClick={() => {
+              // setQueryToAdd(props.query);
+            }}
+          />
+        ),
+      });
+    }
+  }, []);
+
+  useKeyboardShortcuts();
+
+  return (
+    <div
+      className={cx(styles.pageScrollbarWrapper, {
+        [styles.correlationsEditorIndicator]: showCorrelationEditorBar,
+      })}
+    >
+      <SplitPaneWrapper
+        splitOrientation="vertical"
+        paneSize={widthCalc}
+        minSize={MIN_PANE_WIDTH}
+        maxSize={MIN_PANE_WIDTH * -1}
+        primary="second"
+        splitVisible={hasSplit}
+        parentStyle={showCorrelationEditorBar ? { height: `calc(100% - ${theme.spacing(6)}` } : {}} // button = 4, padding = 1 x 2
+        paneStyle={{ overflow: 'auto', display: 'flex', flexDirection: 'column' }}
+        onDragFinished={(size) => size && updateSplitSize(size)}
+      >
+        {panes.map(([exploreId]) => {
+          return (
+            <ErrorBoundaryAlert key={exploreId} style="page">
+              <ExplorePaneContainer exploreId={exploreId} queryBuilderOnly={true} />
+            </ErrorBoundaryAlert>
+          );
+        })}
+      </SplitPaneWrapper>
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    pageScrollbarWrapper: css({
+      width: '100%',
+      flexGrow: 1,
+      minHeight: 0,
+      height: '100%',
+      position: 'relative',
+      overflow: 'hidden',
+    }),
+    correlationsEditorIndicator: css({
+      borderLeft: `4px solid ${theme.colors.primary.main}`,
+      borderRight: `4px solid ${theme.colors.primary.main}`,
+      borderBottom: `4px solid ${theme.colors.primary.main}`,
+      overflow: 'scroll',
+    }),
+  };
+};

--- a/public/app/features/explore/QueryRows.tsx
+++ b/public/app/features/explore/QueryRows.tsx
@@ -15,6 +15,7 @@ import { getExploreItemSelector } from './state/selectors';
 
 interface Props {
   exploreId: string;
+  queryBuilderOnly?: boolean;
 }
 
 const makeSelectors = (exploreId: string) => {
@@ -31,7 +32,7 @@ const makeSelectors = (exploreId: string) => {
   };
 };
 
-export const QueryRows = ({ exploreId }: Props) => {
+export const QueryRows = ({ exploreId, queryBuilderOnly }: Props) => {
   const dispatch = useDispatch();
   const { getQueries, getDatasourceInstanceSettings, getQueryResponse, getHistory, getEventBridge } = useMemo(
     () => makeSelectors(exploreId),
@@ -88,6 +89,7 @@ export const QueryRows = ({ exploreId }: Props) => {
       app={CoreApp.Explore}
       history={history}
       eventBus={eventBridge}
+      queryBuilderOnly={queryBuilderOnly}
       queryRowWrapper={(children, refId) => (
         <ContentOutlineItem
           title={refId}

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -70,6 +70,7 @@ export interface Props<TQuery extends DataQuery> {
   onQueryToggled?: (queryStatus?: boolean | undefined) => void;
   collapsable?: boolean;
   hideRefId?: boolean;
+  queryBuilderOnly?: boolean;
 }
 
 interface State<TQuery extends DataQuery> {
@@ -271,7 +272,7 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
   }
 
   renderPluginEditor = () => {
-    const { query, onChange, queries, onRunQuery, onAddQuery, app = CoreApp.PanelEditor, history } = this.props;
+    const { query, onChange, queries, onRunQuery, onAddQuery, app = CoreApp.PanelEditor, history, queryBuilderOnly } = this.props;
     const { datasource, data } = this.state;
 
     if (this.isWaitingForDatasourceToLoad()) {
@@ -300,6 +301,7 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
               queries={queries}
               app={app}
               history={history}
+              queryBuilderOnly={queryBuilderOnly}
             />
           </DataSourcePluginContextProvider>
         );
@@ -531,7 +533,7 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
   };
 
   render() {
-    const { query, index, visualization, collapsable, hideActionButtons } = this.props;
+    const { query, index, visualization, collapsable, hideActionButtons, queryBuilderOnly } = this.props;
     const { datasource, showingHelp, data } = this.state;
     const isHidden = query.hide;
     const error =
@@ -552,12 +554,13 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
       <div data-testid="query-editor-row" aria-label={selectors.components.QueryEditorRows.rows}>
         <QueryOperationRow
           id={this.id}
-          draggable={!hideActionButtons}
+          draggable={!queryBuilderOnly && !hideActionButtons}
           collapsable={collapsable}
           index={index}
           headerElement={this.renderHeader}
           actions={hideActionButtons ? undefined : this.renderActions}
           onOpen={this.onOpen}
+          queryBuilderOnly={queryBuilderOnly}
         >
           <div className={rowClasses} id={this.id}>
             <ErrorBoundaryAlert>

--- a/public/app/features/query/components/QueryEditorRows.tsx
+++ b/public/app/features/query/components/QueryEditorRows.tsx
@@ -35,6 +35,7 @@ export interface Props {
   onQueryRemoved?: () => void;
   onQueryToggled?: (queryStatus?: boolean | undefined) => void;
   queryRowWrapper?: (children: ReactNode, refId: string) => ReactNode;
+  queryBuilderOnly?: boolean;
 }
 
 export class QueryEditorRows extends PureComponent<Props> {
@@ -143,6 +144,7 @@ export class QueryEditorRows extends PureComponent<Props> {
       onQueryRemoved,
       onQueryToggled,
       queryRowWrapper,
+      queryBuilderOnly,
     } = this.props;
 
     return (
@@ -177,6 +179,7 @@ export class QueryEditorRows extends PureComponent<Props> {
                       app={app}
                       history={history}
                       eventBus={eventBus}
+                      queryBuilderOnly={queryBuilderOnly}
                     />
                   );
 

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -160,6 +160,14 @@ export function getAppRoutes(): RouteDescriptor[] {
       ),
     },
     {
+      path: '/promql-editor',
+      pageClass: 'page-promql-editor',
+      roles: () => contextSrv.evaluatePermission([AccessControlAction.DataSourcesExplore]),
+      component: SafeDynamicImport(() =>
+          import(/* webpackChunkName: "explore" */ 'app/features/explore/PromqlEditorPage')
+      ),
+    },
+    {
       path: '/apps',
       component: () => <NavLandingPage navId="apps" />,
     },


### PR DESCRIPTION
Add a new page for promql editor.

A variable `queryBuilderOnly` is passed to hide unnecessary
UI components.