### PR TITLE
Set default value to .*

### DIFF
--- a/public/app/features/dashboard-scene/settings/variables/components/SelectionOptionsForm.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/SelectionOptionsForm.tsx
@@ -40,7 +40,7 @@ export function SelectionOptionsForm({
       />
       {includeAll && (
         <VariableTextField
-          defaultValue={allValue ?? '.*'}
+          defaultValue={(allValue?.length ?? 0 > 0) ? allValue ?? '' : '.*'}
           onBlur={onAllValueChange}
           name="Custom all value"
           testId={selectors.pages.Dashboard.Settings.Variables.Edit.General.selectionOptionsCustomAllInput}


### PR DESCRIPTION
If allValue is empty, grafana passes the all value
as 'value1|value2|value3'... which can be large
if the label has a large number of values.

Set default allValue to .*