### PR TITLE
Fix flakiness in updating query

### DIFF
--- a/packages/grafana-prometheus/src/querybuilder/components/PromQueryEditorSelector.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/PromQueryEditorSelector.tsx
@@ -106,13 +106,11 @@ export const PromQueryEditorSelector = memo<Props>((props) => {
         return
       }
 
-      if (query.expr !== payload?.query) {
-        onChange({
-          ...query,
-          expr: payload?.query,
-        });
-        onRunQuery();
-      }
+      onChange({
+        ...query,
+        expr: payload?.query,
+      });
+      onRunQuery();
     };
 
     window.addEventListener('message', handleEvent, false);


### PR DESCRIPTION
`query.expr` is not the latest query in the system.

Remove condition so that query events are always applied.