### PR TITLE
Maintain local “editorMode” state

### DIFF
--- a/packages/grafana-prometheus/src/querybuilder/components/PromQueryEditorSelector.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/PromQueryEditorSelector.tsx
@@ -91,8 +91,7 @@ export const PromQueryEditorSelector = memo<Props>((props) => {
   const { flag: explain, setFlag: setExplain } = useFlag(promQueryEditorExplainKey);
 
   const query = getQueryWithDefaults(props.query, app, defaultEditor);
-  // This should be filled in from the defaults by now.
-   // Pull in the defaults once
+  // This should be filled in from the defaults by now.. Pull in the defaults once
   const initial = getQueryWithDefaults(props.query, app, defaultEditor);
   // Track mode locally so it never gets yanked out from under us
   const [editorMode, setEditorMode] = useState<QueryEditorMode>(initial.editorMode!);

--- a/packages/grafana-prometheus/src/querybuilder/components/PromQueryEditorSelector.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/PromQueryEditorSelector.tsx
@@ -92,7 +92,10 @@ export const PromQueryEditorSelector = memo<Props>((props) => {
 
   const query = getQueryWithDefaults(props.query, app, defaultEditor);
   // This should be filled in from the defaults by now.
-  const editorMode = query.editorMode!;
+   // Pull in the defaults once
+  const initial = getQueryWithDefaults(props.query, app, defaultEditor);
+  // Track mode locally so it never gets yanked out from under us
+  const [editorMode, setEditorMode] = useState<QueryEditorMode>(initial.editorMode!);
   useEffect(() => {
     const handleEvent = (event: { data: any; origin: string }) => {
       const { type, payload } = event.data;
@@ -138,6 +141,8 @@ export const PromQueryEditorSelector = memo<Props>((props) => {
         }
       }
       changeEditorMode(query, newMetricEditorMode, onChange);
+      setEditorMode(newMetricEditorMode);
+
       if (queryBuilderOnly) {
         // Trigger onRunQuery to change URL to reflect the new editor mode.
         onRunQuery();

--- a/packages/grafana-prometheus/src/querybuilder/components/PromQueryEditorSelector.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/PromQueryEditorSelector.tsx
@@ -92,9 +92,8 @@ export const PromQueryEditorSelector = memo<Props>((props) => {
 
   const query = getQueryWithDefaults(props.query, app, defaultEditor);
   // This should be filled in from the defaults by now.. Pull in the defaults once
-  const initial = getQueryWithDefaults(props.query, app, defaultEditor);
   // Track mode locally so it never gets yanked out from under us
-  const [editorMode, setEditorMode] = useState<QueryEditorMode>(initial.editorMode!);
+  const [editorMode, setEditorMode] = useState<QueryEditorMode>(query.editorMode!);
   useEffect(() => {
     const handleEvent = (event: { data: any; origin: string }) => {
       const { type, payload } = event.data;


### PR DESCRIPTION
Closes D-2414

#### Description of Change
Keep editorMode in a useState so we never rely on props.query.editorMode coming back from the parent. Use that local state to drive both our toggle and our onChangeInternal merge

#### Testing
- Tested locally
- Tested on dev