### PR TITLE
Add option to disable assureBaseURL

### DIFF
--- a/public/app/features/dashboard-scene/inspect/PanelInspectDrawer.tsx
+++ b/public/app/features/dashboard-scene/inspect/PanelInspectDrawer.tsx
@@ -101,6 +101,7 @@ export class PanelInspectDrawer extends SceneObjectBase<PanelInspectDrawerState>
           inspect: null,
           inspectTab: null,
         },
+        disableAssureBaseUrl: true,
       })
     );
   };

--- a/public/app/features/dashboard-scene/utils/urlBuilders.ts
+++ b/public/app/features/dashboard-scene/utils/urlBuilders.ts
@@ -25,6 +25,8 @@ export interface DashboardUrlOptions {
   timeZone?: string;
   // Check if we are on the home dashboard
   isHomeDashboard?: boolean;
+
+  disableAssureBaseUrl?: boolean;
 }
 
 export function getDashboardUrl(options: DashboardUrlOptions) {
@@ -80,6 +82,10 @@ export function getDashboardUrl(options: DashboardUrlOptions) {
 
   if (options.absolute) {
     return config.appUrl + relativeUrl.slice(1);
+  }
+
+  if (options.disableAssureBaseUrl) {
+    return relativeUrl;
   }
 
   return assureBaseUrl(relativeUrl);


### PR DESCRIPTION
Add option to disable assureBaseURL.

Inspect drawer adds baseURL twice.