### PR TITLE
Replace fuzzy search with regex search

### DIFF
--- a/packages/grafana-prometheus/src/querybuilder/components/MetricSelect.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/MetricSelect.tsx
@@ -31,6 +31,7 @@ import { PromVisualQuery } from '../types';
 
 import { MetricsModal } from './metrics-modal/MetricsModal';
 import { tracking } from './metrics-modal/state/helpers';
+import { convertToPromqlCompliantString } from './metrics-modal/uFuzzy';
 
 // We are matching words split with space
 const splitSeparator = ' ';
@@ -73,7 +74,7 @@ export function MetricSelect({
     {
       value: 'BrowseMetrics',
       label: 'Metrics explorer',
-      description: 'Browse and filter all metrics and metadata with a fuzzy search',
+      description: 'Browse and filter all metrics and metadata',
     },
   ];
 
@@ -89,7 +90,7 @@ export function MetricSelect({
         return true;
       }
 
-      const searchWords = searchQuery.split(splitSeparator);
+      const searchWords = searchQuery.split(splitSeparator).map(convertToPromqlCompliantString);
 
       return searchWords.reduce((acc, cur) => {
         const matcheSearch = label.toLowerCase().includes(cur.toLowerCase());

--- a/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModal.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModal.tsx
@@ -44,7 +44,7 @@ import {
 } from './state/state';
 import { getStyles } from './styles';
 import { MetricsData, PromFilterOption } from './types';
-import { debouncedFuzzySearch } from './uFuzzy';
+import { debouncedPromqlCompliantMatch } from './uFuzzy';
 
 export type MetricsModalProps = {
   datasource: PrometheusDatasource;
@@ -135,9 +135,9 @@ export const MetricsModal = (props: MetricsModalProps) => {
       // search either the names or all metadata
       // fuzzy search go!
       if (fullMetaSearchVal) {
-        debouncedFuzzySearch(Object.keys(state.metaHaystackDictionary), query, fuzzyMetaDispatch);
+        debouncedPromqlCompliantMatch(Object.keys(state.metaHaystackDictionary), query, fuzzyMetaDispatch);
       } else {
-        debouncedFuzzySearch(Object.keys(state.nameHaystackDictionary), query, fuzzyNameDispatch);
+        debouncedPromqlCompliantMatch(Object.keys(state.nameHaystackDictionary), query, fuzzyNameDispatch);
       }
     }
   }

--- a/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/uFuzzy.ts
+++ b/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/uFuzzy.ts
@@ -44,3 +44,48 @@ export function fuzzySearch(haystack: string[], query: string, dispatcher: (data
 }
 
 export const debouncedFuzzySearch = debounceLodash(fuzzySearch, 300);
+
+function isDigit(character: string) {
+  const charCode = character.charCodeAt(0);
+  const CHAR_CODE_0 = '0'.charCodeAt(0);
+  const CHAR_CODE_9 = '9'.charCodeAt(0);
+
+  return charCode >= CHAR_CODE_0 && charCode <= CHAR_CODE_9;
+}
+
+function isLetter(character: string) {
+  const charCode = character.charCodeAt(0);
+  const CHAR_CODE_A = 'a'.charCodeAt(0);
+  const CHAR_CODE_Z = 'z'.charCodeAt(0);
+  const CHAR_CODE_A_UPPER = 'A'.charCodeAt(0);
+  const CHAR_CODE_Z_UPPER = 'Z'.charCodeAt(0);
+
+  return (charCode >= CHAR_CODE_A && charCode <= CHAR_CODE_Z) || 
+    (charCode >= CHAR_CODE_A_UPPER && charCode <= CHAR_CODE_Z_UPPER);
+}
+
+export function convertToPromqlCompliantString(query: string) {
+  return query
+  .split('')
+  .map((c) => {
+    if(isDigit(c) || isLetter(c) || c === '_' || c === ':') {
+      return c;
+    }
+
+    return '_';
+  }).join('');
+}
+
+// TODO: replace with fuzzySearch when we have bandwidth to implement performant fuzzy search
+function promqlCompliantMatch(haystack: string[], query: string, dispatcher: (data: string[][]) => void) {
+  if (!query) {
+    dispatcher([[], []]);
+  }
+
+  dispatcher([
+    haystack.filter((item) => item.includes(convertToPromqlCompliantString(query))),
+    [],
+  ]);
+}
+
+export const debouncedPromqlCompliantMatch = debounceLodash(promqlCompliantMatch, 300);


### PR DESCRIPTION
## Description of change

Earlier, metric search in Grafana builder mode was not able to efficiently search for promql combatible metric strings (with . and _)

This PR removes fuzzy search in order to introduce searching promql compatible metric strings with substring search
