### PR TITLE
Handle null data in dropdown

### DIFF
--- a/packages/grafana-prometheus/src/language_provider.ts
+++ b/packages/grafana-prometheus/src/language_provider.ts
@@ -388,7 +388,7 @@ export default class PromQlLanguageProvider extends LanguageProvider {
 
     const data: string[] = await this.request(url, [], urlParams, this.getDefaultCacheHeaders());
     // Convert string array to Record<string , []>
-    return data.reduce((ac, a) => ({ ...ac, [a]: '' }), {});
+    return data?.reduce((ac, a) => ({ ...ac, [a]: '' }), {}) || [];
   };
 
   /**


### PR DESCRIPTION
Closes D-1589

Data can be null when metric does not exist.