### PR TITLE
Hide builder mode if query is not supported

### DIFF
--- a/packages/grafana-prometheus/src/querybuilder/components/PromQueryEditorSelector.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/PromQueryEditorSelector.tsx
@@ -89,6 +89,7 @@ export const PromQueryEditorSelector = memo<Props>((props) => {
   const [dataIsStale, setDataIsStale] = useState(false);
   const delayTrigger = useMemo(() => new DelayedTriggerState(onRunQuery), [onRunQuery]);
   const { flag: explain, setFlag: setExplain } = useFlag(promQueryEditorExplainKey);
+  const [hideBuilderMode, setHideBuilderMode] = useState<boolean>(false);
 
   const query = getQueryWithDefaults(props.query, app, defaultEditor);
   // This should be filled in from the defaults by now.. Pull in the defaults once
@@ -121,6 +122,17 @@ export const PromQueryEditorSelector = memo<Props>((props) => {
     };
   }, []);
 
+  useEffect(() => {
+    const result = buildVisualQueryFromString(query.expr || '');
+    // If there are errors, give user a chance to decide if they want to go to builder as that can lose some data.
+    if (result.errors.length) {
+      setHideBuilderMode(true);
+    } else {
+      setHideBuilderMode(false);
+    }
+  }, [query.expr]);
+
+  console.log(hideBuilderMode);
   const onEditorModeChange = useCallback(
     (newMetricEditorMode: QueryEditorMode) => {
       reportInteraction('user_grafana_prometheus_editor_mode_clicked', {
@@ -243,7 +255,7 @@ export const PromQueryEditorSelector = memo<Props>((props) => {
         )}
         <PromQueryCodeEditorAutocompleteInfo datasourceUid={props.datasource.uid} editorMode={editorMode} />
         <div data-testid={selectors.components.DataSource.Prometheus.queryEditor.editorToggle}>
-          <QueryEditorModeToggle mode={editorMode} onChange={onEditorModeChange} />
+          <QueryEditorModeToggle mode={editorMode} onChange={onEditorModeChange} hideBuilder={hideBuilderMode} />
         </div>
       </EditorHeader>
       <Space v={0.5} />

--- a/packages/grafana-prometheus/src/querybuilder/shared/QueryEditorModeToggle.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/shared/QueryEditorModeToggle.tsx
@@ -6,6 +6,7 @@ import { QueryEditorMode } from './types';
 export interface Props {
   mode: QueryEditorMode;
   onChange: (mode: QueryEditorMode) => void;
+  hideBuilder?: boolean;
 }
 
 const editorModes = [
@@ -13,10 +14,12 @@ const editorModes = [
   { label: 'Code', value: QueryEditorMode.Code },
 ];
 
-export function QueryEditorModeToggle({ mode, onChange }: Props) {
+export function QueryEditorModeToggle({ mode, onChange, hideBuilder }: Props) {
   return (
     <div data-testid={'QueryEditorModeToggle'}>
-      <RadioButtonGroup options={editorModes} size="sm" value={mode} onChange={onChange} />
+      <RadioButtonGroup options={editorModes?.filter(
+        (option) => !(hideBuilder && option.value === QueryEditorMode.Builder)
+      )} size="sm" value={mode} onChange={onChange} />
     </div>
   );
 }


### PR DESCRIPTION
If builder mode is not supported, hide the button