### PR TITLE
Show correct results for multi-filter alert-list dashboards

### DIFF
--- a/public/app/features/alerting/unified/api/alertRuleApi.ts
+++ b/public/app/features/alerting/unified/api/alertRuleApi.ts
@@ -137,9 +137,10 @@ export const alertRuleApi = alertingApi.injectEndpoints({
         filter?: FetchPromRulesFilter;
         state?: string[];
         matcher?: Matcher[];
+        sourceUID?: string;
       }
     >({
-      query: ({ limitAlerts, identifier, filter, state, matcher }) => {
+      query: ({ limitAlerts, identifier, filter, state, matcher, sourceUID }) => {
         const searchParams = new URLSearchParams();
 
         // if we're fetching for Grafana managed rules, we should add a limit to the number of alert instances
@@ -155,11 +156,15 @@ export const alertRuleApi = alertingApi.injectEndpoints({
 
         const filterParams = getRulesFilterSearchParams(filter);
         const params = { ...filterParams, ...Object.fromEntries(searchParams) };
+        const url = PROM_RULES_URL.replace(
+          GRAFANA_RULES_SOURCE_NAME,
+          sourceUID ?? GRAFANA_RULES_SOURCE_NAME,
+        );
 
-        return { url: PROM_RULES_URL, params: paramsWithMatcherAndState(params, state, matcher) };
+        return { url, params: paramsWithMatcherAndState(params, state, matcher) };
       },
-      transformResponse: (response: PromRulesResponse): RuleNamespace[] => {
-        return groupRulesByFileName(response.data.groups, GRAFANA_RULES_SOURCE_NAME);
+      transformResponse: (response: PromRulesResponse, _, { sourceUID }): RuleNamespace[] => {
+        return groupRulesByFileName(response.data.groups, sourceUID ?? GRAFANA_RULES_SOURCE_NAME);
       },
     }),
 

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -235,13 +235,17 @@ interface FetchPromRulesRulesActionProps {
 
 export function fetchAllPromAndRulerRulesAction(
   force = false,
-  options: FetchPromRulesRulesActionProps = {}
+  options: FetchPromRulesRulesActionProps = {},
+  dataSourceNameBlocklist: string[] = [],
 ): ThunkResult<Promise<void>> {
   return async (dispatch, getStore) => {
     const allStartLoadingTs = performance.now();
+    const dataSourceNames =
+      getAllRulesSourceNames()
+        .filter((name) => !dataSourceNameBlocklist.includes(name));
 
     await Promise.allSettled(
-      getAllRulesSourceNames().map(async (rulesSourceName) => {
+      dataSourceNames.map(async (rulesSourceName) => {
         await dispatch(fetchRulesSourceBuildInfoAction({ rulesSourceName }));
 
         const { promRules, rulerRules, dataSources } = getStore().unifiedAlerting;

--- a/public/app/features/alerting/unified/utils/datasource.ts
+++ b/public/app/features/alerting/unified/utils/datasource.ts
@@ -207,6 +207,16 @@ export function getAllRulesSources(): RulesSource[] {
   return availableRulesSources;
 }
 
+export function getOodleRulesSources(): Array<Exclude<RulesSource, 'grafana'>> {
+  return getRulesDataSources().filter(
+    (ds) => (
+      isCloudRulesSource(ds)
+      && ds.type === DataSourceType.Prometheus
+      && JSON.stringify(ds.jsonData).toLowerCase().includes('oodle')
+    )
+  );
+}
+
 export function getRulesSourceName(rulesSource: RulesSource): string {
   return isCloudRulesSource(rulesSource) ? rulesSource.name : rulesSource;
 }

--- a/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
@@ -157,7 +157,12 @@ function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
   } = usePrometheusRulesByNamespaceQuery(
     {
       limitAlerts: limitInstances ? INSTANCES_DISPLAY_LIMIT : undefined,
-      matcher: matcherList,
+      matcher: [{
+        name: 'name',
+        value: `.*${props.options.alertName}.*`,
+        isRegex: true,
+        isEqual: true
+      }, ...matcherList],
       state: stateList,
       sourceUID: oodleSourcesToFetchFrom.map((ds) => ds.uid)[0],
     },


### PR DESCRIPTION
Fixes D-3633, D-3657

Give same treatment to Oodle-managed rules as
that given to the Grafana-managed rules in
https://github.com/grafana/grafana/pull/70482

### Before
<img width="1480" height="267" alt="image" src="https://github.com/user-attachments/assets/b92948da-c903-4c14-9c21-e649a28f6660" />

### After
<img width="1486" height="256" alt="image" src="https://github.com/user-attachments/assets/e6e8ad2b-7425-47ac-8e7a-e3bd754cf01c" />