### PR TITLE
Memoise calls to getPanelById

### DIFF
--- a/public/app/features/panel/components/PanelDataErrorView.tsx
+++ b/public/app/features/panel/components/PanelDataErrorView.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { css } from '@emotion/css';
 
 import {
@@ -27,7 +28,7 @@ export function PanelDataErrorView(props: PanelDataErrorViewProps) {
   const { dataSummary } = builder;
   const message = getMessageFor(props, dataSummary);
   const dispatch = useDispatch();
-  const panel = getDashboardSrv().getCurrent()?.getPanelById(props.panelId);
+  const panel = useMemo(() => getDashboardSrv().getCurrent()?.getPanelById(props.panelId), [props.panelId]);
 
   const openVizPicker = () => {
     store.setObject(LS_VISUALIZATION_SELECT_TAB_KEY, VisualizationSelectPaneTab.Suggestions);


### PR DESCRIPTION
### Description

Through investigation into the Performance panel, one UI performance gap was identified - there are redundant `getPanelById` calls invoked on every component re-render

This PR reduces the number of `getPanelById` calls by memoising the computed result for a given panel ID - refer [useMemo](https://react.dev/reference/react/useMemo) for details

### Test Plan
Tested locally, by checking console logs while scrolling through a dashboard

Steps:
1. Make [this change](https://github.com/oodle-ai/grafana/commit/2b36f678820a7f943177aefbc30137c93baa23b9) locally to track getPanelById calls before vs after useMemo
2. Scroll through any dashboard

<img width="1677" height="53" alt="Screenshot 2025-09-22 at 1 39 01 PM" src="https://github.com/user-attachments/assets/6d82be85-5c5c-4b0b-bbed-51d1f0af5621" />

Here,
- `PanelDataErrorView:renders` indicates the number of times the `PanelDataErrorView` component has been rendered. Since `getPanelById` was initially called every time this component rendered, this count is also equal to the number of times `getPanelById` was called without `useMemo` (Before)
- `PanelDataErrorView:getPanelById`  indicates the number of times `getPanelById` was called with useMemo (After)

This screenshot indicates that `getPanelById` calls have reduced from 439 to 133 in this case
which is a ~70% reduction in calls to the `getPanelById` function within the `PanelDataErrorView` component