### PR TITLE
Make Alert list panel backward-compatible

### DIFF
--- a/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
@@ -552,15 +552,27 @@ function filterRules(props: PanelProps<UnifiedAlertListOptions>, rules: Combined
       (options.stateFilter.pending && alertingRule.state === PromAlertingRuleState.Pending) ||
       (options.stateFilter.normal && alertingRule.state === PromAlertingRuleState.Inactive);
 
-    // Check severity-based filters
+    // Check severity-based filters (only if they exist for backwards compatibility)
     const severity = alertingRule.labels?.['severity'];
     const matchesSeverityFilter =
-      (options.stateFilter.critical && severity === 'critical') ||
-      (options.stateFilter.warn && severity === 'warn') ||
-      (options.stateFilter.noData && severity === 'no_data');
+      (options.stateFilter.critical === true && severity === 'critical') ||
+      (options.stateFilter.warn === true && severity === 'warn') ||
+      (options.stateFilter.noData === true && severity === 'no_data');
 
-    // Check if any severity filters are enabled
-    const hasSeverityFilters = options.stateFilter.critical || options.stateFilter.warn || options.stateFilter.noData;
+    // Check if this is an "old" panel by seeing if all severity filters are undefined or false
+    const allSeverityFiltersDisabled =
+      (options.stateFilter.critical === false || options.stateFilter.critical === undefined) &&
+      (options.stateFilter.warn === false || options.stateFilter.warn === undefined) &&
+      (options.stateFilter.noData === false || options.stateFilter.noData === undefined);
+
+    if (allSeverityFiltersDisabled) {
+      // This is an old panel - show all alerts regardless of severity labels
+      return true;
+    }
+
+    // Check if any severity filters are enabled (only count as enabled if explicitly true)
+    const hasSeverityFilters =
+      options.stateFilter.critical === true || options.stateFilter.warn === true || options.stateFilter.noData === true;
     const hasStateFilters = options.stateFilter.firing || options.stateFilter.pending || options.stateFilter.normal;
 
     if (hasSeverityFilters && hasStateFilters) {
@@ -578,10 +590,8 @@ function filterRules(props: PanelProps<UnifiedAlertListOptions>, rules: Combined
       }
       return matchesStateFilter;
     } else {
-      // If no filters are enabled, exclude all alerts with severity labels
-      const severity = alertingRule.labels?.['severity'];
-      const hasSeverityLabel = severity !== undefined && severity !== null && severity !== '';
-      return !hasSeverityLabel; // Show only alerts without severity labels
+      // If no filters are enabled, show all alerts
+      return true;
     }
   });
 

--- a/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
@@ -265,7 +265,7 @@ function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
 
   const renderLoading = grafanaRulesLoading || oodleRulesLoading || (dispatched && loading && !haveResults);
 
-  const havePreviousResults = Object.values(promRulesRequests).some((state) => state.result);
+  const havePreviousResults = Object.values(promRulesRequests).some((state: any) => state.result);
 
   // Calculate counts based on the filtered rules that are actually displayed
   // Use the same filtering logic as the display to ensure counts match what's shown

--- a/public/app/plugins/panel/alertlist/module.tsx
+++ b/public/app/plugins/panel/alertlist/module.tsx
@@ -113,21 +113,21 @@ const unifiedAlertList = new PanelPlugin<UnifiedAlertListOptions>(UnifiedAlertLi
       path: 'stateFilter.critical',
       name: 'Show Critical',
       defaultValue: true,
-      category: ['Filter firing alert by severity (All firing alerts are shown if no severity filters are enabled)'],
+      category: ['Filter firing alert by severity (shows all when none enabled)'],
       showIf: ({ stateFilter }) => stateFilter.firing,
     })
     .addBooleanSwitch({
       path: 'stateFilter.warn',
       name: 'Show Warn',
       defaultValue: true,
-      category: ['Filter firing alert by severity (All firing alerts are shown if no severity filters are enabled)'],
+      category: ['Filter firing alert by severity (shows all when none enabled)'],
       showIf: ({ stateFilter }) => stateFilter.firing,
     })
     .addBooleanSwitch({
       path: 'stateFilter.noData',
       name: 'Show No Data',
       defaultValue: true,
-      category: ['Filter firing alert by severity (All firing alerts are shown if no severity filters are enabled)'],
+      category: ['Filter firing alert by severity (shows all when none enabled)'],
       showIf: ({ stateFilter }) => stateFilter.firing,
     });
 });

--- a/public/app/plugins/panel/alertlist/module.tsx
+++ b/public/app/plugins/panel/alertlist/module.tsx
@@ -113,21 +113,21 @@ const unifiedAlertList = new PanelPlugin<UnifiedAlertListOptions>(UnifiedAlertLi
       path: 'stateFilter.critical',
       name: 'Show Critical',
       defaultValue: true,
-      category: ['Filter firing alert by severity'],
+      category: ['Filter firing alert by severity (All firing alerts are shown if no severity filters are enabled)'],
       showIf: ({ stateFilter }) => stateFilter.firing,
     })
     .addBooleanSwitch({
       path: 'stateFilter.warn',
       name: 'Show Warn',
       defaultValue: true,
-      category: ['Filter firing alert by severity'],
+      category: ['Filter firing alert by severity (All firing alerts are shown if no severity filters are enabled)'],
       showIf: ({ stateFilter }) => stateFilter.firing,
     })
     .addBooleanSwitch({
       path: 'stateFilter.noData',
       name: 'Show No Data',
       defaultValue: true,
-      category: ['Filter firing alert by severity'],
+      category: ['Filter firing alert by severity (All firing alerts are shown if no severity filters are enabled)'],
       showIf: ({ stateFilter }) => stateFilter.firing,
     });
 });

--- a/public/app/plugins/panel/alertlist/module.tsx
+++ b/public/app/plugins/panel/alertlist/module.tsx
@@ -71,7 +71,7 @@ const unifiedAlertList = new PanelPlugin<UnifiedAlertListOptions>(UnifiedAlertLi
           { label: 'Time (desc)', value: SortOrder.TimeDesc },
         ],
       },
-      defaultValue: SortOrder.AlphaAsc,
+      defaultValue: SortOrder.Importance,
       category: ['Options'],
     })
     .addTextInput({
@@ -89,28 +89,46 @@ const unifiedAlertList = new PanelPlugin<UnifiedAlertListOptions>(UnifiedAlertLi
       category: ['Filter'],
     })
     .addBooleanSwitch({
+      path: 'stateFilter.firing',
+      name: 'Show Firing',
+      description: 'Show alerts that are currently active. You can also filter by severity if this is enabled.',
+      defaultValue: true,
+      category: ['Filter alerts by state'],
+    })
+    .addBooleanSwitch({
+      path: 'stateFilter.pending',
+      name: 'Show Pending',
+      defaultValue: true,
+      category: ['Filter alerts by state'],
+      showIf: () => false,
+    })
+    .addBooleanSwitch({
       path: 'stateFilter.normal',
-      name: 'Show Normal',
-      defaultValue: false,
-      category: ['Alert state filter'],
+      name: 'Show OK',
+      description: 'Show alerts that are in a normal or resolved state.',
+      defaultValue: true,
+      category: ['Filter alerts by state'],
     })
     .addBooleanSwitch({
       path: 'stateFilter.critical',
-      name: 'Critical',
-      defaultValue: false,
-      category: ['Firing Alert severity filter'],
+      name: 'Show Critical',
+      defaultValue: true,
+      category: ['Filter firing alert by severity'],
+      showIf: ({ stateFilter }) => stateFilter.firing,
     })
     .addBooleanSwitch({
       path: 'stateFilter.warn',
-      name: 'Warn',
-      defaultValue: false,
-      category: ['Firing Alert severity filter'],
+      name: 'Show Warn',
+      defaultValue: true,
+      category: ['Filter firing alert by severity'],
+      showIf: ({ stateFilter }) => stateFilter.firing,
     })
     .addBooleanSwitch({
       path: 'stateFilter.noData',
-      name: 'No Data',
-      defaultValue: false,
-      category: ['Firing Alert severity filter'],
+      name: 'Show No Data',
+      defaultValue: true,
+      category: ['Filter firing alert by severity'],
+      showIf: ({ stateFilter }) => stateFilter.firing,
     });
 });
 

--- a/public/app/plugins/panel/alertlist/types.ts
+++ b/public/app/plugins/panel/alertlist/types.ts
@@ -46,9 +46,9 @@ export interface StateFilter {
   inactive?: boolean; // backwards compat
   normal: boolean;
   error: boolean;
-  critical: boolean;
-  warn: boolean;
-  noData: boolean;
+  critical?: boolean; // backwards compat - added later
+  warn?: boolean; // backwards compat - added later
+  noData?: boolean; // backwards compat - added later
 }
 
 export interface UnifiedAlertListOptions {


### PR DESCRIPTION
Closes D-3970
Closes D-3976

### Description of Change
#### Why
- Old alert list panels created before severity filters were added were not displaying any alerts due to strict filtering logic
- The default sorting order was not set to "Importance" as required, causing alerts to be displayed in alphabetical order instead of by priority

#### What
- Added backwards compatibility logic to detect old panels where all severity filters are disabled (false/undefined) and show all alerts regardless of severity labels
- Updated StateFilter interface to make severity filters optional for backwards compatibility
- Set default sorting order to "Importance" in the panel options builder
- Added descriptive text in the severity filter category header to explain backwards compatibility behavior


#### Before
<img width="2473" height="1214" alt="Screenshot 2025-09-26 at 3 49 00 PM" src="https://github.com/user-attachments/assets/c35c61d3-1edc-4bfe-ab7e-9aae0ea8f3e8" />

#### After
<img width="2551" height="1171" alt="Screenshot 2025-09-26 at 3 49 25 PM" src="https://github.com/user-attachments/assets/a0cc357f-665f-46fc-a7b2-67cfa6f30798" />

### Test plan
- Tested locally by importing an old dashboard
- Tested on dev