### PR TITLE
Stop deep-copying dataframe in `applyFieldOverrides`

### DIFF
--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -101,21 +101,25 @@ export function applyFieldOverrides(options: ApplyFieldOverrideOptions): DataFra
 
   return options.data.map((originalFrame, index) => {
     // Need to define this new frame here as it's passed to the getLinkSupplier function inside the fields loop
-    const newFrame: DataFrame = { ...originalFrame };
-    // Copy fields
-    newFrame.fields = newFrame.fields.map((field) => {
-      return {
-        ...field,
-        config: cloneDeep(field.config),
-        state: {
-          ...field.state,
-        },
-      };
-    });
+    const newFrame = originalFrame;
+    // const newFrame: DataFrame = { ...originalFrame };
+    // // Copy fields
+    // newFrame.fields = newFrame.fields.map((field) => {
+    //   return {
+    //     ...field,
+    //     config: cloneDeep(field.config),
+    //     state: {
+    //       ...field.state,
+    //     },
+    //   };
+    // });
 
     for (const field of newFrame.fields) {
       const config = field.config;
 
+      if (!field.state) {
+        field.state = {};
+      }
       field.state!.scopedVars = {
         __dataContext: {
           value: {


### PR DESCRIPTION
Ref D-4091

This has similar effect on CPU as disabling GC altogether.
Grafana image just before this change:
`sha256:5705189a999768d3aca1648b20526ebd823589462b1693eb9be988156dae0cdc`
