### PR TITLE
Add client-side validation for math expressions

### DIFF
--- a/public/app/features/expressions/ExpressionQueryEditor.tsx
+++ b/public/app/features/expressions/ExpressionQueryEditor.tsx
@@ -80,7 +80,9 @@ export function ExpressionQueryEditor(props: Props) {
 
     switch (query.type) {
       case ExpressionQueryType.math:
-        return <Math onChange={onChange} query={query} labelWidth={labelWidth} onRunQuery={onRunQuery} />;
+        return (
+          <Math onChange={onChange} query={query} labelWidth={labelWidth} onRunQuery={onRunQuery} queries={queries} />
+        );
 
       case ExpressionQueryType.reduce:
         return <Reduce refIds={refIds} onChange={onChange} labelWidth={labelWidth} query={query} />;

--- a/public/app/features/expressions/components/Math.tsx
+++ b/public/app/features/expressions/components/Math.tsx
@@ -1,26 +1,38 @@
 import { css } from '@emotion/css';
-import { ChangeEvent } from 'react';
+import { ChangeEvent, useState } from 'react';
 import * as React from 'react';
 
-import { GrafanaTheme2 } from '@grafana/data';
+import { DataQueryError, GrafanaTheme2 } from '@grafana/data';
 import { Icon, InlineField, InlineLabel, TextArea, Toggletip, useStyles2, Stack } from '@grafana/ui';
 
+import { QueryErrorAlert } from '../../query/components/QueryErrorAlert';
 import { ExpressionQuery } from '../types';
+
+import { validateMathExpression } from './MathValidation';
 
 interface Props {
   labelWidth: number | 'auto';
   query: ExpressionQuery;
   onChange: (query: ExpressionQuery) => void;
   onRunQuery: () => void;
+  queries?: Array<{ refId: string }>; // Available queries for variable validation
 }
 
 const mathPlaceholder =
   'Math operations on one or more queries. You reference the query by ${refId} ie. $A, $B, $C etc\n' +
   'The sum of two scalar values: $A + $B > 10';
 
-export const Math = ({ labelWidth, onChange, query, onRunQuery }: Props) => {
+export const Math = ({ labelWidth, onChange, query, onRunQuery, queries }: Props) => {
+  const [validationError, setValidationError] = useState<DataQueryError | null>(null);
+
   const onExpressionChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
-    onChange({ ...query, expression: event.target.value });
+    const newExpression = event.target.value;
+    onChange({ ...query, expression: newExpression });
+
+    // Clear validation error when user starts typing
+    if (validationError) {
+      setValidationError(null);
+    }
   };
 
   const styles = useStyles2(getStyles);
@@ -31,8 +43,23 @@ export const Math = ({ labelWidth, onChange, query, onRunQuery }: Props) => {
     }
   };
 
+  const handleBlur = () => {
+    const errorMessage = validateMathExpression(query.expression || '', queries);
+    if (errorMessage) {
+      // Show validation error using QueryErrorAlert
+      setValidationError({
+        message: errorMessage,
+        refId: query.refId,
+      });
+    } else {
+      // Clear any existing validation error and execute query
+      setValidationError(null);
+      executeQuery();
+    }
+  };
+
   return (
-    <Stack>
+    <Stack direction="column">
       <InlineField
         label={
           <InlineLabel width="auto">
@@ -128,10 +155,11 @@ export const Math = ({ labelWidth, onChange, query, onRunQuery }: Props) => {
           onChange={onExpressionChange}
           rows={1}
           placeholder={mathPlaceholder}
-          onBlur={executeQuery}
+          onBlur={handleBlur}
           style={{ minWidth: 250, lineHeight: '26px', minHeight: 32 }}
         />
       </InlineField>
+      {validationError && <QueryErrorAlert error={validationError} />}
     </Stack>
   );
 };

--- a/public/app/features/expressions/components/MathValidation.test.tsx
+++ b/public/app/features/expressions/components/MathValidation.test.tsx
@@ -1,0 +1,108 @@
+import { validateMathExpression } from './MathValidation';
+
+// Mock the validation function by extracting it
+// This is a simple test to verify our validation logic works
+
+describe('Math Expression Validation', () => {
+  const mockQueries = [{ refId: 'A' }, { refId: 'B' }, { refId: 'C' }];
+
+  describe('Variable validation', () => {
+    it('should validate existing variables', () => {
+      expect(validateMathExpression('$A + $B', mockQueries)).toBeNull();
+      expect(validateMathExpression('${A} + ${B}', mockQueries)).toBeNull();
+    });
+
+    it('should reject non-existent variables', () => {
+      expect(validateMathExpression('$D + $B', mockQueries)).toBe('Variable $D does not exist');
+      expect(validateMathExpression('${D} + ${B}', mockQueries)).toBe('Variable ${D} does not exist');
+    });
+  });
+
+  describe('Incomplete expressions', () => {
+    it('should reject expressions ending with operators', () => {
+      expect(validateMathExpression('$A +', mockQueries)).toBe('Expression cannot end with an operator');
+      expect(validateMathExpression('$A *', mockQueries)).toBe('Expression cannot end with an operator');
+      expect(validateMathExpression('$A /', mockQueries)).toBe('Expression cannot end with an operator');
+    });
+
+    it('should reject expressions starting with most operators', () => {
+      expect(validateMathExpression('+ $A', mockQueries)).toBe('Expression cannot start with this operator');
+      expect(validateMathExpression('* $A', mockQueries)).toBe('Expression cannot start with this operator');
+      expect(validateMathExpression('/ $A', mockQueries)).toBe('Expression cannot start with this operator');
+    });
+
+    it('should allow expressions starting with unary minus and not', () => {
+      expect(validateMathExpression('- $A', mockQueries)).toBeNull();
+      expect(validateMathExpression('! $A', mockQueries)).toBeNull();
+    });
+  });
+
+  describe('Function validation', () => {
+    it('should validate built-in functions', () => {
+      expect(validateMathExpression('abs($A)', mockQueries)).toBeNull();
+      expect(validateMathExpression('log($A)', mockQueries)).toBeNull();
+      expect(validateMathExpression('round($A)', mockQueries)).toBeNull();
+    });
+
+    it('should reject unknown functions', () => {
+      expect(validateMathExpression('sqrt($A)', mockQueries)).toBe('Unknown function: sqrt');
+      expect(validateMathExpression('sin($A)', mockQueries)).toBe('Unknown function: sin');
+    });
+
+    it('should reject empty function calls', () => {
+      expect(validateMathExpression('abs()', mockQueries)).toBe('Empty function call is not valid');
+    });
+  });
+
+  describe('Syntax validation', () => {
+    it('should validate parentheses balance', () => {
+      expect(validateMathExpression('($A + $B)', mockQueries)).toBeNull();
+      expect(validateMathExpression('(($A + $B) * $C)', mockQueries)).toBeNull();
+    });
+
+    it('should reject unmatched parentheses', () => {
+      expect(validateMathExpression('($A + $B', mockQueries)).toBe('Unmatched opening parenthesis');
+      expect(validateMathExpression('$A + $B)', mockQueries)).toBe('Unmatched closing parenthesis');
+    });
+
+    it('should reject consecutive operators', () => {
+      expect(validateMathExpression('$A ++ $B', mockQueries)).toBe('Consecutive operators are not valid');
+      expect(validateMathExpression('$A // $B', mockQueries)).toBe('Consecutive operators are not valid');
+    });
+
+    it('should allow unary minus in appropriate contexts', () => {
+      expect(validateMathExpression('$A + -$B', mockQueries)).toBeNull();
+      expect(validateMathExpression('-$A + $B', mockQueries)).toBeNull();
+    });
+  });
+
+  describe('Number validation', () => {
+    it('should validate various number formats', () => {
+      expect(validateMathExpression('1 + 2', mockQueries)).toBeNull();
+      expect(validateMathExpression('1.5 + 2.7', mockQueries)).toBeNull();
+      expect(validateMathExpression('1e3 + 2e-4', mockQueries)).toBeNull();
+      expect(validateMathExpression('0x1A + 0xFF', mockQueries)).toBeNull();
+    });
+  });
+
+  describe('String validation', () => {
+    it('should validate string literals', () => {
+      expect(validateMathExpression('"hello" + "world"', mockQueries)).toBeNull();
+    });
+
+    it('should reject unterminated strings', () => {
+      expect(validateMathExpression('"hello', mockQueries)).toBe('Unterminated string');
+    });
+  });
+
+  describe('Variable format validation', () => {
+    it('should validate ${var} format', () => {
+      expect(validateMathExpression('${A} + ${B}', mockQueries)).toBeNull();
+    });
+
+    it('should reject incomplete ${var} format', () => {
+      expect(validateMathExpression('${A + ${B}', mockQueries)).toBe('Unterminated variable missing closing }');
+      expect(validateMathExpression('${} + ${B}', mockQueries)).toBe('Incomplete variable');
+    });
+  });
+});

--- a/public/app/features/expressions/components/MathValidation.ts
+++ b/public/app/features/expressions/components/MathValidation.ts
@@ -1,0 +1,385 @@
+// Comprehensive validation function for math expressions
+// This closely matches the backend parser implementation from pkg/expr/mathexp/parse/
+
+interface Token {
+  type: string;
+  value: string;
+}
+
+export const validateMathExpression = (
+  expression: string,
+  availableQueries?: Array<{ refId: string }>
+): string | null => {
+  if (!expression || expression.trim() === '') {
+    return null; // Empty expressions are valid (will be handled by backend)
+  }
+
+  const trimmed = expression.trim();
+
+  // Built-in functions from pkg/expr/mathexp/funcs.go
+  const builtinFunctions = new Set([
+    'abs',
+    'log',
+    'nan',
+    'is_nan',
+    'inf',
+    'infn',
+    'is_inf',
+    'null',
+    'is_null',
+    'is_number',
+    'round',
+    'ceil',
+    'floor',
+  ]);
+
+  // Create set of available query refIds for variable validation
+  const availableRefIds = new Set(availableQueries?.map((q) => q.refId) || []);
+
+  // Tokenize the expression similar to the lexer
+  const tokens = tokenizeExpression(trimmed);
+  if (typeof tokens === 'string') {
+    return tokens; // Return error message from tokenization
+  }
+
+  // Validate token sequence according to grammar
+  return validateTokenSequence(tokens, builtinFunctions, availableRefIds);
+
+  // Tokenization function based on lex.go
+  function tokenizeExpression(input: string): string | Token[] {
+    const tokens: Token[] = [];
+    let pos = 0;
+
+    while (pos < input.length) {
+      const char = input[pos];
+
+      // Skip whitespace
+      if (/\s/.test(char)) {
+        pos++;
+        continue;
+      }
+
+      // Handle variables ($A or ${var})
+      if (char === '$') {
+        const varResult = parseVariable(input, pos);
+        if (typeof varResult === 'string') {
+          return varResult; // Error
+        }
+        tokens.push(varResult.token);
+        pos = varResult.nextPos;
+        continue;
+      }
+
+      // Handle strings
+      if (char === '"') {
+        const strResult = parseString(input, pos);
+        if (typeof strResult === 'string') {
+          return strResult; // Error
+        }
+        tokens.push(strResult.token);
+        pos = strResult.nextPos;
+        continue;
+      }
+
+      // Handle numbers
+      if (/\d/.test(char) || char === '.') {
+        const numResult = parseNumber(input, pos);
+        if (typeof numResult === 'string') {
+          return numResult; // Error
+        }
+        tokens.push(numResult.token);
+        pos = numResult.nextPos;
+        continue;
+      }
+
+      // Handle functions (letters and underscores)
+      if (/[a-zA-Z_]/.test(char)) {
+        const funcResult = parseFunction(input, pos);
+        tokens.push(funcResult.token);
+        pos = funcResult.nextPos;
+        continue;
+      }
+
+      // Handle symbols and operators
+      if (/[!<>=&|+\-*/%()]/.test(char)) {
+        const symbolResult = parseSymbol(input, pos);
+        if (typeof symbolResult === 'string') {
+          return symbolResult; // Error
+        }
+        tokens.push(symbolResult.token);
+        pos = symbolResult.nextPos;
+        continue;
+      }
+
+      // Invalid character
+      return `Invalid character: ${char}`;
+    }
+
+    return tokens;
+  }
+
+  function parseVariable(input: string, start: number): string | { token: Token; nextPos: number } {
+    let pos = start + 1; // Skip $
+
+    if (input[pos] === '{') {
+      // ${var} format
+      pos++;
+      let hasChar = false;
+      while (pos < input.length) {
+        const char = input[pos];
+        if (char === '}') {
+          if (!hasChar) {
+            return 'Incomplete variable';
+          }
+          return {
+            token: { type: 'var', value: input.slice(start, pos + 1) },
+            nextPos: pos + 1,
+          };
+        }
+        if (char === '\n' || char === '\r') {
+          return 'Unterminated variable missing closing }';
+        }
+        if (/[a-zA-Z0-9_\s]/.test(char)) {
+          hasChar = true;
+        } else if (char === '+' || char === '-' || char === '*' || char === '/' || char === '(' || char === ')') {
+          // These characters indicate the variable is incomplete
+          return 'Unterminated variable missing closing }';
+        } else {
+          return 'Unsupported variable character';
+        }
+        pos++;
+      }
+      return 'Unterminated variable missing closing }';
+    } else {
+      // $A format
+      let hasChar = false;
+      while (pos < input.length && /[a-zA-Z0-9_]/.test(input[pos])) {
+        hasChar = true;
+        pos++;
+      }
+      if (!hasChar) {
+        return 'Incomplete variable';
+      }
+      return {
+        token: { type: 'var', value: input.slice(start, pos) },
+        nextPos: pos,
+      };
+    }
+  }
+
+  function parseString(input: string, start: number): string | { token: Token; nextPos: number } {
+    let pos = start + 1; // Skip opening quote
+    while (pos < input.length) {
+      if (input[pos] === '"') {
+        return {
+          token: { type: 'string', value: input.slice(start, pos + 1) },
+          nextPos: pos + 1,
+        };
+      }
+      pos++;
+    }
+    return 'Unterminated string';
+  }
+
+  function parseNumber(input: string, start: number): string | { token: Token; nextPos: number } {
+    let pos = start;
+
+    // Handle hex numbers (0x...)
+    if (input[pos] === '0' && pos + 1 < input.length && /[xX]/.test(input[pos + 1])) {
+      pos += 2;
+      while (pos < input.length && /[0-9a-fA-F]/.test(input[pos])) {
+        pos++;
+      }
+    } else {
+      // Handle decimal numbers
+      while (pos < input.length && /\d/.test(input[pos])) {
+        pos++;
+      }
+
+      // Handle decimal point
+      if (pos < input.length && input[pos] === '.') {
+        pos++;
+        while (pos < input.length && /\d/.test(input[pos])) {
+          pos++;
+        }
+      }
+
+      // Handle scientific notation
+      if (pos < input.length && /[eE]/.test(input[pos])) {
+        pos++;
+        if (pos < input.length && /[+-]/.test(input[pos])) {
+          pos++;
+        }
+        while (pos < input.length && /\d/.test(input[pos])) {
+          pos++;
+        }
+      }
+    }
+
+    return {
+      token: { type: 'number', value: input.slice(start, pos) },
+      nextPos: pos,
+    };
+  }
+
+  function parseFunction(input: string, start: number): { token: Token; nextPos: number } {
+    let pos = start;
+    while (pos < input.length && /[a-zA-Z0-9_]/.test(input[pos])) {
+      pos++;
+    }
+    return {
+      token: { type: 'func', value: input.slice(start, pos) },
+      nextPos: pos,
+    };
+  }
+
+  function parseSymbol(input: string, start: number): string | { token: Token; nextPos: number } {
+    let pos = start;
+    const char = input[pos];
+
+    // Handle multi-character operators (check these first)
+    if (char === '&' && pos + 1 < input.length && input[pos + 1] === '&') {
+      return { token: { type: '&&', value: '&&' }, nextPos: pos + 2 };
+    }
+    if (char === '|' && pos + 1 < input.length && input[pos + 1] === '|') {
+      return { token: { type: '||', value: '||' }, nextPos: pos + 2 };
+    }
+    if (char === '=' && pos + 1 < input.length && input[pos + 1] === '=') {
+      return { token: { type: '==', value: '==' }, nextPos: pos + 2 };
+    }
+    if (char === '!' && pos + 1 < input.length && input[pos + 1] === '=') {
+      return { token: { type: '!=', value: '!=' }, nextPos: pos + 2 };
+    }
+    if (char === '>' && pos + 1 < input.length && input[pos + 1] === '=') {
+      return { token: { type: '>=', value: '>=' }, nextPos: pos + 2 };
+    }
+    if (char === '<' && pos + 1 < input.length && input[pos + 1] === '=') {
+      return { token: { type: '<=', value: '<=' }, nextPos: pos + 2 };
+    }
+    if (char === '*' && pos + 1 < input.length && input[pos + 1] === '*') {
+      return { token: { type: '**', value: '**' }, nextPos: pos + 2 };
+    }
+
+    // Single character operators
+    if (['!', '>', '<', '+', '-', '*', '/', '%', '(', ')'].includes(char)) {
+      return { token: { type: char, value: char }, nextPos: pos + 1 };
+    }
+
+    return `Invalid operator: ${char}`;
+  }
+
+  function validateTokenSequence(
+    tokens: Token[],
+    builtinFunctions: Set<string>,
+    availableRefIds: Set<string>
+  ): string | null {
+    if (tokens.length === 0) {
+      return null;
+    }
+
+    // Check for incomplete expressions (ends with operator)
+    const lastToken = tokens[tokens.length - 1];
+    if (isOperator(lastToken.type)) {
+      return 'Expression cannot end with an operator';
+    }
+
+    // Check for incomplete expressions (starts with most operators)
+    const firstToken = tokens[0];
+    if (isOperator(firstToken.type) && !['-', '!'].includes(firstToken.type)) {
+      return 'Expression cannot start with this operator';
+    }
+
+    // Check for empty function calls
+    for (let i = 0; i < tokens.length - 1; i++) {
+      if (tokens[i].type === 'func' && tokens[i + 1].type === '(') {
+        // Look for matching closing parenthesis
+        let parenCount = 1;
+        let j = i + 2;
+        while (j < tokens.length && parenCount > 0) {
+          if (tokens[j].type === '(') {
+            parenCount++;
+          }
+          if (tokens[j].type === ')') {
+            parenCount--;
+          }
+          j++;
+        }
+        if (parenCount === 0 && j === i + 3) {
+          return 'Empty function call is not valid';
+        }
+      }
+    }
+
+    // Validate function names
+    for (const token of tokens) {
+      if (token.type === 'func' && !builtinFunctions.has(token.value)) {
+        return `Unknown function: ${token.value}`;
+      }
+    }
+
+    // Validate variable references
+    for (const token of tokens) {
+      if (token.type === 'var') {
+        const varName = token.value.startsWith('${')
+          ? token.value.slice(2, -1) // Remove ${ and }
+          : token.value.slice(1); // Remove $
+
+        if (!availableRefIds.has(varName)) {
+          return `Variable ${token.value} does not exist`;
+        }
+      }
+    }
+
+    // Check parentheses balance
+    let parenCount = 0;
+    for (const token of tokens) {
+      if (token.type === '(') {
+        parenCount++;
+      }
+      if (token.type === ')') {
+        parenCount--;
+      }
+      if (parenCount < 0) {
+        return 'Unmatched closing parenthesis';
+      }
+    }
+    if (parenCount > 0) {
+      return 'Unmatched opening parenthesis';
+    }
+
+    // Validate expression structure according to grammar
+    return validateExpressionGrammar(tokens);
+  }
+
+  function validateExpressionGrammar(tokens: Token[]): string | null {
+    // This is a simplified grammar validation
+    // The full grammar is: O -> A {"||" A}, A -> C {"&&" C}, etc.
+
+    if (tokens.length === 0) {
+      return null;
+    }
+
+    // Check for invalid operator sequences
+    for (let i = 0; i < tokens.length - 1; i++) {
+      const current = tokens[i];
+      const next = tokens[i + 1];
+
+      // Consecutive operators (except for unary minus and not)
+      if (isOperator(current.type) && isOperator(next.type)) {
+        // Allow unary minus and not after operators, at start, or after opening parenthesis
+        if (
+          !(next.type === '-' && (i === 0 || isOperator(tokens[i - 1].type) || tokens[i - 1].type === '(')) &&
+          !(next.type === '!' && (i === 0 || isOperator(tokens[i - 1].type) || tokens[i - 1].type === '('))
+        ) {
+          return 'Consecutive operators are not valid';
+        }
+      }
+    }
+
+    return null;
+  }
+
+  function isOperator(type: string): boolean {
+    return ['!', '&&', '||', '>', '<', '>=', '<=', '==', '!=', '+', '-', '*', '/', '%', '**'].includes(type);
+  }
+};


### PR DESCRIPTION
### Description of change
#### Why
- Users currently get generic "Query data error" messages for invalid math expressions
- No immediate feedback when typing invalid syntax
- Server receives obviously invalid expressions, wasting resources
- Poor user experience with unclear error messages

#### What
- Added client-side validation that matches backend parser behavior
- Validates variables exist against available queries
- Detects syntax errors (incomplete expressions, invalid operators, etc.)
- Shows specific error messages using existing QueryErrorAlert component
- Extracted validation logic into reusable MathValidation.ts module
- Added comprehensive test suite

#### Before
https://github.com/user-attachments/assets/8630a5cb-8897-4160-bfa4-43e1b75fa280

#### After
https://github.com/user-attachments/assets/39ee7d66-32f4-4710-9f2f-21ec43b056fd

### Test plan
- Tested in dev mode
- Build and test
