### PR TITLE
Revert "Stop deep-copying dataframe in `applyFieldOverrides` (#106)"

### DIFF
--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -101,25 +101,21 @@ export function applyFieldOverrides(options: ApplyFieldOverrideOptions): DataFra
 
   return options.data.map((originalFrame, index) => {
     // Need to define this new frame here as it's passed to the getLinkSupplier function inside the fields loop
-    const newFrame = originalFrame;
-    // const newFrame: DataFrame = { ...originalFrame };
-    // // Copy fields
-    // newFrame.fields = newFrame.fields.map((field) => {
-    //   return {
-    //     ...field,
-    //     config: cloneDeep(field.config),
-    //     state: {
-    //       ...field.state,
-    //     },
-    //   };
-    // });
+    const newFrame: DataFrame = { ...originalFrame };
+    // Copy fields
+    newFrame.fields = newFrame.fields.map((field) => {
+      return {
+        ...field,
+        config: cloneDeep(field.config),
+        state: {
+          ...field.state,
+        },
+      };
+    });
 
     for (const field of newFrame.fields) {
       const config = field.config;
 
-      if (!field.state) {
-        field.state = {};
-      }
       field.state!.scopedVars = {
         __dataContext: {
           value: {


### PR DESCRIPTION
Close D-4112

The PR #106 led to two bugs on explore page:
 - When a legend is clicked, nothing happens
 - Hover tooltips are empty
