### PR TITLE
Add total value to stacked timeseries panel tooltip 

### DIFF
--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltipContent.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltipContent.tsx
@@ -34,7 +34,7 @@ export const VizTooltipContent = ({
 
   return (
     <div className={styles.wrapper} style={scrollableStyle}>
-      {items.map(({ label, value, color, colorIndicator, colorPlacement, isActive, lineStyle }, i) => (
+      {items.map(({ label, value, color, colorIndicator, colorPlacement, isActive, lineStyle, showDivider }, i) => (
         <VizTooltipRow
           key={i}
           label={label}
@@ -46,6 +46,7 @@ export const VizTooltipContent = ({
           justify={'space-between'}
           isPinned={isPinned}
           lineStyle={lineStyle}
+          showDivider={showDivider}
           showValueScroll={!scrollable}
         />
       ))}

--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltipRow.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltipRow.tsx
@@ -16,6 +16,7 @@ interface VizTooltipRowProps extends Omit<VizTooltipItem, 'value'> {
   justify?: string;
   isActive?: boolean; // for series list
   marginRight?: string;
+  showDivider?: boolean; // Add divider below this item
   isPinned: boolean;
   showValueScroll?: boolean;
 }
@@ -38,6 +39,7 @@ export const VizTooltipRow = ({
   justify = 'flex-start',
   isActive = false,
   marginRight = '0px',
+  showDivider = false,
   isPinned,
   lineStyle,
   showValueScroll,
@@ -127,83 +129,86 @@ export const VizTooltipRow = ({
   }
 
   return (
-    <div className={styles.contentWrapper}>
-      {(color || label) && (
-        <div className={styles.valueWrapper}>
-          {color && colorPlacement === ColorPlacement.first && (
-            <VizTooltipColorIndicator color={color} colorIndicator={colorIndicator} lineStyle={lineStyle} />
-          )}
-          {!isPinned ? (
-            <div className={cx(styles.label, isActive && styles.activeSeries)}>{label}</div>
-          ) : (
-            <>
-              <Tooltip content={label} interactive={false} show={showLabelTooltip}>
-                <>
-                  {showCopySuccess && copiedText?.label && (
-                    <InlineToast placement="top" referenceElement={labelRef.current}>
-                      {SUCCESSFULLY_COPIED_TEXT}
-                    </InlineToast>
-                  )}
-                  {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}
-                  <div
-                    className={cx(styles.label, isActive && styles.activeSeries, navigator?.clipboard && styles.copy)}
-                    onMouseEnter={onMouseEnterLabel}
-                    onMouseLeave={onMouseLeaveLabel}
-                    onClick={() => copyToClipboard(label, LabelValueTypes.label)}
-                    ref={labelRef}
-                  >
-                    {label}
-                  </div>
-                </>
-              </Tooltip>
-            </>
-          )}
-        </div>
-      )}
-
-      <div className={styles.valueWrapper}>
-        {color && colorPlacement === ColorPlacement.leading && (
-          <VizTooltipColorIndicator
-            color={color}
-            colorIndicator={colorIndicator}
-            position={ColorIndicatorPosition.Leading}
-            lineStyle={lineStyle}
-          />
+    <>
+      <div className={styles.contentWrapper}>
+        {(color || label) && (
+          <div className={styles.valueWrapper}>
+            {color && colorPlacement === ColorPlacement.first && (
+              <VizTooltipColorIndicator color={color} colorIndicator={colorIndicator} lineStyle={lineStyle} />
+            )}
+            {!isPinned ? (
+              <div className={cx(styles.label, isActive && styles.activeSeries)}>{label}</div>
+            ) : (
+              <>
+                <Tooltip content={label} interactive={false} show={showLabelTooltip}>
+                  <>
+                    {showCopySuccess && copiedText?.label && (
+                      <InlineToast placement="top" referenceElement={labelRef.current}>
+                        {SUCCESSFULLY_COPIED_TEXT}
+                      </InlineToast>
+                    )}
+                    {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}
+                    <div
+                      className={cx(styles.label, isActive && styles.activeSeries, navigator?.clipboard && styles.copy)}
+                      onMouseEnter={onMouseEnterLabel}
+                      onMouseLeave={onMouseLeaveLabel}
+                      onClick={() => copyToClipboard(label, LabelValueTypes.label)}
+                      ref={labelRef}
+                    >
+                      {label}
+                    </div>
+                  </>
+                </Tooltip>
+              </>
+            )}
+          </div>
         )}
 
-        {!isPinned ? (
-          <div className={cx(styles.value, isActive)} style={innerValueScrollStyle}>
-            {value}
-          </div>
-        ) : (
-          <>
-            {showCopySuccess && copiedText?.value && (
-              <InlineToast placement="top" referenceElement={valueRef.current}>
-                {SUCCESSFULLY_COPIED_TEXT}
-              </InlineToast>
-            )}
-            {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}
-            <div
-              className={cx(styles.value, isActive, navigator?.clipboard && styles.copy)}
-              style={innerValueScrollStyle}
-              onClick={() => copyToClipboard(value ? value.toString() : '', LabelValueTypes.value)}
-              ref={valueRef}
-            >
+        <div className={styles.valueWrapper}>
+          {color && colorPlacement === ColorPlacement.leading && (
+            <VizTooltipColorIndicator
+              color={color}
+              colorIndicator={colorIndicator}
+              position={ColorIndicatorPosition.Leading}
+              lineStyle={lineStyle}
+            />
+          )}
+
+          {!isPinned ? (
+            <div className={cx(styles.value, isActive)} style={innerValueScrollStyle}>
               {value}
             </div>
-          </>
-        )}
+          ) : (
+            <>
+              {showCopySuccess && copiedText?.value && (
+                <InlineToast placement="top" referenceElement={valueRef.current}>
+                  {SUCCESSFULLY_COPIED_TEXT}
+                </InlineToast>
+              )}
+              {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}
+              <div
+                className={cx(styles.value, isActive, navigator?.clipboard && styles.copy)}
+                style={innerValueScrollStyle}
+                onClick={() => copyToClipboard(value ? value.toString() : '', LabelValueTypes.value)}
+                ref={valueRef}
+              >
+                {value}
+              </div>
+            </>
+          )}
 
-        {color && colorPlacement === ColorPlacement.trailing && (
-          <VizTooltipColorIndicator
-            color={color}
-            colorIndicator={colorIndicator}
-            position={ColorIndicatorPosition.Trailing}
-            lineStyle={lineStyle}
-          />
-        )}
+          {color && colorPlacement === ColorPlacement.trailing && (
+            <VizTooltipColorIndicator
+              color={color}
+              colorIndicator={colorIndicator}
+              position={ColorIndicatorPosition.Trailing}
+              lineStyle={lineStyle}
+            />
+          )}
+        </div>
       </div>
-    </div>
+      {showDivider && <div className={styles.divider} />}
+    </>
   );
 };
 
@@ -236,5 +241,12 @@ const getStyles = (theme: GrafanaTheme2, justify: string, marginRight: string) =
   }),
   copy: css({
     cursor: 'pointer',
+  }),
+  divider: css({
+    borderBottom: `1px solid ${theme.colors.border.medium}`,
+    marginTop: theme.spacing(0.25),
+    marginBottom: theme.spacing(0.25),
+    marginLeft: -10,
+    marginRight: -10,
   }),
 });

--- a/packages/grafana-ui/src/components/VizTooltip/types.ts
+++ b/packages/grafana-ui/src/components/VizTooltip/types.ts
@@ -27,6 +27,7 @@ export interface VizTooltipItem {
   colorPlacement?: ColorPlacement;
   isActive?: boolean;
   lineStyle?: LineStyle;
+  showDivider?: boolean; // Add divider below this item
 
   // internal/tmp for sorting
   numeric?: number;

--- a/packages/grafana-ui/src/components/VizTooltip/utils.test.ts
+++ b/packages/grafana-ui/src/components/VizTooltip/utils.test.ts
@@ -224,28 +224,28 @@ describe('utils', () => {
     it('displays the right content in multi mode', () => {
       const rows = getContentItems(fields, xField, dataIdxs, null, TooltipDisplayMode.Multi, SortOrder.None);
       expect(rows.length).toBe(3); // 2 series + 1 total
-      expect(rows[0].value).toBe('20');
-      expect(rows[1].value).toBe('-26');
-      expect(rows[2].label).toBe('Total');
-      expect(rows[2].value).toBe('-6'); // 20 + (-26)
+      expect(rows[0].label).toBe('Total');
+      expect(rows[0].value).toBe('-6'); // 20 + (-26)
+      expect(rows[1].value).toBe('20');
+      expect(rows[2].value).toBe('-26');
     });
 
     it('displays the values sorted ASC', () => {
       const rows = getContentItems(fields, xField, dataIdxs, null, TooltipDisplayMode.Multi, SortOrder.Ascending);
       expect(rows.length).toBe(3); // 2 series + 1 total
-      expect(rows[0].value).toBe('-26');
-      expect(rows[1].value).toBe('20');
-      expect(rows[2].label).toBe('Total');
-      expect(rows[2].value).toBe('-6'); // 20 + (-26)
+      expect(rows[0].label).toBe('Total');
+      expect(rows[0].value).toBe('-6'); // 20 + (-26)
+      expect(rows[1].value).toBe('-26');
+      expect(rows[2].value).toBe('20');
     });
 
     it('displays the values sorted DESC', () => {
       const rows = getContentItems(fields, xField, dataIdxs, null, TooltipDisplayMode.Multi, SortOrder.Descending);
       expect(rows.length).toBe(3); // 2 series + 1 total
-      expect(rows[0].value).toBe('20');
-      expect(rows[1].value).toBe('-26');
-      expect(rows[2].label).toBe('Total');
-      expect(rows[2].value).toBe('-6'); // 20 + (-26)
+      expect(rows[0].label).toBe('Total');
+      expect(rows[0].value).toBe('-6'); // 20 + (-26)
+      expect(rows[1].value).toBe('20');
+      expect(rows[2].value).toBe('-26');
     });
 
     it('displays the correct value when NULL values', () => {
@@ -403,11 +403,11 @@ describe('utils', () => {
     it('displays total line for stacked charts with 3+ series', () => {
       const rows = getContentItems(fields, xField, dataIdxs, null, TooltipDisplayMode.Multi, SortOrder.None);
       expect(rows.length).toBe(4); // 3 series + 1 total
-      expect(rows[0].value).toBe('20');
-      expect(rows[1].value).toBe('25');
-      expect(rows[2].value).toBe('10');
-      expect(rows[3].label).toBe('Total');
-      expect(rows[3].value).toBe('55'); // 20 + 25 + 10
+      expect(rows[0].label).toBe('Total');
+      expect(rows[0].value).toBe('55'); // 20 + 25 + 10
+      expect(rows[1].value).toBe('20');
+      expect(rows[2].value).toBe('25');
+      expect(rows[3].value).toBe('10');
     });
   });
 });

--- a/packages/grafana-ui/src/components/VizTooltip/utils.test.ts
+++ b/packages/grafana-ui/src/components/VizTooltip/utils.test.ts
@@ -223,23 +223,29 @@ describe('utils', () => {
 
     it('displays the right content in multi mode', () => {
       const rows = getContentItems(fields, xField, dataIdxs, null, TooltipDisplayMode.Multi, SortOrder.None);
-      expect(rows.length).toBe(2);
+      expect(rows.length).toBe(3); // 2 series + 1 total
       expect(rows[0].value).toBe('20');
       expect(rows[1].value).toBe('-26');
+      expect(rows[2].label).toBe('Total');
+      expect(rows[2].value).toBe('-6'); // 20 + (-26)
     });
 
     it('displays the values sorted ASC', () => {
       const rows = getContentItems(fields, xField, dataIdxs, null, TooltipDisplayMode.Multi, SortOrder.Ascending);
-      expect(rows.length).toBe(2);
+      expect(rows.length).toBe(3); // 2 series + 1 total
       expect(rows[0].value).toBe('-26');
       expect(rows[1].value).toBe('20');
+      expect(rows[2].label).toBe('Total');
+      expect(rows[2].value).toBe('-6'); // 20 + (-26)
     });
 
     it('displays the values sorted DESC', () => {
       const rows = getContentItems(fields, xField, dataIdxs, null, TooltipDisplayMode.Multi, SortOrder.Descending);
-      expect(rows.length).toBe(2);
+      expect(rows.length).toBe(3); // 2 series + 1 total
       expect(rows[0].value).toBe('20');
       expect(rows[1].value).toBe('-26');
+      expect(rows[2].label).toBe('Total');
+      expect(rows[2].value).toBe('-6'); // 20 + (-26)
     });
 
     it('displays the correct value when NULL values', () => {
@@ -330,6 +336,78 @@ describe('utils', () => {
       expect(rows.length).toBe(2);
       expect(rows[0].value).toBe('NORMAL');
       expect(rows[1].value).toBe('LOW');
+    });
+  });
+
+  describe('it tests getContentItems with stacked charts (3+ series)', () => {
+    const timeValues = [1707833954056, 1707838274056, 1707842594056];
+    const seriesAValues = [10, 20, 30];
+    const seriesBValues = [15, 25, 35];
+    const seriesCValues = [5, 10, 15];
+
+    const frame = {
+      name: 'stacked',
+      length: timeValues.length,
+      fields: [
+        {
+          name: 'time',
+          type: FieldType.time,
+          values: timeValues[0],
+          config: {},
+          display: (value: string) => ({
+            text: value,
+            color: undefined,
+            numeric: NaN,
+          }),
+        },
+        {
+          name: 'A-series',
+          type: FieldType.number,
+          values: seriesAValues,
+          config: {},
+          display: (value: string) => ({
+            text: value,
+            color: undefined,
+            numeric: Number(value),
+          }),
+        },
+        {
+          name: 'B-series',
+          type: FieldType.number,
+          values: seriesBValues,
+          config: {},
+          display: (value: string) => ({
+            text: value,
+            color: undefined,
+            numeric: Number(value),
+          }),
+        },
+        {
+          name: 'C-series',
+          type: FieldType.number,
+          values: seriesCValues,
+          config: {},
+          display: (value: string) => ({
+            text: value,
+            color: undefined,
+            numeric: Number(value),
+          }),
+        },
+      ],
+    } as unknown as DataFrame;
+
+    const fields = frame.fields;
+    const xField = frame.fields[0];
+    const dataIdxs = [1, 1, 1, 1];
+
+    it('displays total line for stacked charts with 3+ series', () => {
+      const rows = getContentItems(fields, xField, dataIdxs, null, TooltipDisplayMode.Multi, SortOrder.None);
+      expect(rows.length).toBe(4); // 3 series + 1 total
+      expect(rows[0].value).toBe('20');
+      expect(rows[1].value).toBe('25');
+      expect(rows[2].value).toBe('10');
+      expect(rows[3].label).toBe('Total');
+      expect(rows[3].value).toBe('55'); // 20 + 25 + 10
     });
   });
 });

--- a/packages/grafana-ui/src/components/VizTooltip/utils.ts
+++ b/packages/grafana-ui/src/components/VizTooltip/utils.ts
@@ -84,6 +84,10 @@ export const getContentItems = (
   let rows: VizTooltipItem[] = [];
 
   let allNumeric = true;
+  let totalNumericValue = 0; // Sum of all numeric values for total line
+  let hasNumericFields = false; // Whether we have any valid numeric fields
+  let processedNumericFields = 0; // Count of processed numeric fields
+  let firstNumericField: Field | undefined; // First numeric field for total line formatting
 
   for (let i = 0; i < fields.length; i++) {
     const field = fields[i];
@@ -129,6 +133,18 @@ export const getContentItems = (
         ? Number.MIN_SAFE_INTEGER
         : Number.MAX_SAFE_INTEGER;
 
+    // Track numeric fields for total calculation and first numeric field
+    if (field.type === FieldType.number && !Number.isNaN(display.numeric)) {
+      totalNumericValue += display.numeric; // Accumulate sum for total
+      hasNumericFields = true; // Mark we have valid numeric fields
+      processedNumericFields++; // Count fields contributing to total
+
+      // Store the first numeric field for total formatting
+      if (!firstNumericField) {
+        firstNumericField = field; // Capture first field for consistent formatting
+      }
+    }
+
     const colorMode = getFieldColorModeForField(field);
 
     let colorIndicator = ColorIndicator.series;
@@ -155,6 +171,23 @@ export const getContentItems = (
     const cmp = allNumeric ? numberCmp : stringCmp;
     const mult = sortOrder === SortOrder.Descending ? -1 : 1;
     rows.sort((a, b) => mult * cmp(a, b));
+  }
+
+  // Add Total line for stacked charts (when there are multiple numeric fields and we're in multi mode)
+  // Show total when we have 2 or more numeric fields - add after sorting to ensure it's always at the end
+  if (hasNumericFields && rows.length >= 2 && mode === TooltipDisplayMode.Multi && processedNumericFields >= 2) {
+    if (firstNumericField) {
+      const totalDisplay = firstNumericField.display!(totalNumericValue); // Use first field's formatter for consistency
+      rows.push({
+        label: 'Total',
+        value: formattedValueToString(totalDisplay),
+        color: FALLBACK_COLOR,
+        colorIndicator: ColorIndicator.series,
+        colorPlacement: ColorPlacement.first,
+        isActive: false,
+        numeric: totalNumericValue, // Raw numeric value for sorting
+      });
+    }
   }
 
   return rows;

--- a/packages/grafana-ui/src/components/VizTooltip/utils.ts
+++ b/packages/grafana-ui/src/components/VizTooltip/utils.ts
@@ -174,11 +174,11 @@ export const getContentItems = (
   }
 
   // Add Total line for stacked charts (when there are multiple numeric fields and we're in multi mode)
-  // Show total when we have 2 or more numeric fields - add after sorting to ensure it's always at the end
+  // Show total when we have 2 or more numeric fields - add after sorting to ensure it's always at the top
   if (hasNumericFields && rows.length >= 2 && mode === TooltipDisplayMode.Multi && processedNumericFields >= 2) {
     if (firstNumericField) {
       const totalDisplay = firstNumericField.display!(totalNumericValue); // Use first field's formatter for consistency
-      rows.push({
+      rows.unshift({
         label: 'Total',
         value: formattedValueToString(totalDisplay),
         color: FALLBACK_COLOR,
@@ -186,6 +186,7 @@ export const getContentItems = (
         colorPlacement: ColorPlacement.first,
         isActive: false,
         numeric: totalNumericValue, // Raw numeric value for sorting
+        showDivider: true, // Add border-bottom divider
       });
     }
   }


### PR DESCRIPTION
### Description of Change
#### Why
Users need to quickly see the total sum of all series values in stacked chart tooltips to better understand the overall magnitude and verify that individual series values add up correctly.

#### What
- Added total line calculation to stacked chart tooltips that shows the sum of all numeric series values
- Positioned total line at the top of the tooltip for immediate visibility
- Added visual divider (border-bottom) between the total and individual series for clear separation
- Total line appears only for multi-series tooltips with 2+ numeric fields and uses consistent formatting from the first numeric field

#### Screensots

##### Bars
<img width="2557" height="1232" alt="Screenshot 2025-10-08 at 4 29 37 PM" src="https://github.com/user-attachments/assets/8445dbc5-eaf3-4af3-8299-5bef4a7e6003" />

##### Lines
<img width="2556" height="1230" alt="Screenshot 2025-10-08 at 4 28 35 PM" src="https://github.com/user-attachments/assets/a2843a7f-afcd-4635-afc9-03b3e19a678d" />

### Test plan
- Added comprehensive test coverage for both 2-series and 3+ series scenarios
- Tested with stacked line and bar charts