### PR TITLE
Allow browser to indicate that a dashboard is updated

### DIFF
--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -593,7 +593,12 @@ func (hs *HTTPServer) postDashboard(c *contextmodel.ReqContext, cmd dashboards.S
 
 	dashboard, saveErr := hs.DashboardService.SaveDashboard(ctx, dashItem, allowUiUpdate)
 
-	if hs.Live != nil {
+	skipNotification := strings.Contains(cmd.Message, "::no_notification::")
+	if skipNotification {
+		hs.log.Info("skipping notification", "dashboardMsg", cmd.Message)
+	}
+
+	if hs.Live != nil && !skipNotification {
 		// Tell everyone listening that the dashboard changed
 		if dashboard == nil {
 			dashboard = dash // the original request

--- a/public/app/features/live/dashboard/dashboardWatcher.ts
+++ b/public/app/features/live/dashboard/dashboardWatcher.ts
@@ -55,8 +55,12 @@ class DashboardWatcher {
   }
 
   watch(uid: string) {
+    window.removeEventListener('message', this.listener);
+    window.addEventListener('message', this.listener);
+
     const live = getGrafanaLiveSrv();
     if (!live) {
+      this.uid = uid;
       return;
     }
 
@@ -95,6 +99,30 @@ class DashboardWatcher {
       }
     }
     return this.lastEditing;
+  }
+
+  private listener = (event: MessageEvent<any>) => {
+    if (
+      event.data?.type !== 'grafana-dashboard-updated' ||
+      event.data?.uid !== this.uid
+    ) {
+      return;
+    }
+
+    const dash = getDashboardSrv().getCurrent();
+    const showPopup = this.editing || (dash?.hasUnsavedChanges() ?? false);
+
+    if (showPopup) {
+      appEvents.publish(
+        new ShowModalReactEvent({
+          component: DashboardChangedModal,
+          props: { event },
+        })
+      );
+    } else {
+      appEvents.emit(AppEvents.alertSuccess, ['Dashboard updated']);
+      this.reloadPage();
+    }
   }
 
   observer = {


### PR DESCRIPTION
Ref D-5078

If the browser is certain that a dashboard is updated,
it can refresh the dashboard directly instead of relying
on websocket events which we have observed to be unreliable.

In this change, we allow an updater to include `::no_notification::`
in the dashboard update message, which disables server-sent
websocket notifications. Such an updater can emit an event in
the browser. We also add the listener for these events in this change.

One downside of this approach is that all the other instances of the
dashboard will never get notified, which is fine since anyway these
notifications do not have a guaranteed delivery and are just on a best
effort basis.