### PR TITLE
Add clone dashboard button to export menu

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/pages.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/pages.ts
@@ -238,6 +238,9 @@ export const versionedPages = {
           exportAsImage: {
             '12.1.0': 'data-testid new export button export as image',
           },
+          cloneDashboard: {
+            '12.1.0': 'data-testid new export button clone dashboard',
+          },
         },
       },
       playlistControls: {

--- a/public/app/features/dashboard-scene/sharing/ExportButton/ExportMenu.tsx
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/ExportMenu.tsx
@@ -59,6 +59,20 @@ export default function ExportMenu({ dashboard }: { dashboard: DashboardScene })
       onClick: () => onMenuItemClick(shareDashboardType.image),
     });
 
+    menuItems.push({
+      shareId: 'clone',
+      testId: newExportButtonSelector.cloneDashboard,
+      icon: 'copy',
+      label: t('share-dashboard.menu.clone-dashboard-title', 'Clone dashboard'),
+      renderCondition: true,
+      onClick: (d: DashboardScene) => {
+        if (!d.state.isEditing) {
+          d.onEnterEditMode();
+        }
+        d.openSaveDrawer({ saveAsCopy: true });
+      },
+    });
+
     return menuItems.filter((item) => item.renderCondition);
   }, []);
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12517,6 +12517,7 @@
   },
   "share-dashboard": {
     "menu": {
+      "clone-dashboard-title": "Clone dashboard",
       "export-image-title": "Export as image",
       "export-json-title": "Export as JSON",
       "share-externally-title": "Share externally",


### PR DESCRIPTION
### Why
Users have requested a copy/clone dashboard button for a quicker workflow. Currently, cloning a dashboard requires entering edit mode and using "Save as copy", which is not easily discoverable.
### What
Added a "Clone dashboard" option to the export dropdown menu that enters edit mode and opens the save-as-copy drawer


https://github.com/user-attachments/assets/57469c9b-e18c-4760-a44f-7a554b5d2ea8



### Test plan
- [X] Used the button to create a copy of a dashboard

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI/menu change that reuses existing edit/save flows; main risk is minor UX/regression in menu behavior and e2e selector stability.
> 
> **Overview**
> Adds a **"Clone dashboard"** entry to the dashboard export dropdown menu.
> 
> Clicking it ensures the dashboard is in edit mode and then opens the save drawer with *Save as copy* enabled, and includes the needed i18n string plus a new e2e selector (`NewExportButton.Menu.cloneDashboard`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7629b9ec33a804cea95712de52dfced2f6c4cad7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->