### PR TITLE
fix: multi-tenant org-sync

### DIFF
--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -56,6 +56,11 @@ type ClientParams struct {
 	SyncTeams bool
 	// SyncOrgRoles will sync the roles from the identity to orgs in grafana
 	SyncOrgRoles bool
+	// AdditiveSyncOrgRoles when true, org role sync will only add/update
+	// memberships present in OrgRoles without removing memberships in other
+	// orgs. Useful in multi-tenant systems where a user can be part of multiple orgs, but
+	// any request, at any given time, carries a single org context.
+	AdditiveSyncOrgRoles bool
 	// CacheAuthProxyKey  if this key is set we will try to cache the user id for proxy client
 	CacheAuthProxyKey string
 	// LookUpParams are the arguments used to look up the entity in the DB.

--- a/pkg/services/authn/authnimpl/sync/org_sync.go
+++ b/pkg/services/authn/authnimpl/sync/org_sync.go
@@ -73,7 +73,12 @@ func (s *OrgSync) SyncOrgRolesHook(ctx context.Context, id *authn.Identity, _ *a
 
 		extRole := id.OrgRoles[orga.OrgID]
 		if extRole == "" {
-			deleteOrgIds = append(deleteOrgIds, orga.OrgID)
+			// Only schedule deletion when NOT in additive mode.
+			// In additive mode, absence from OrgRoles simply
+			// means "this request doesn't concern that org" - not "remove it".
+			if !id.ClientParams.AdditiveSyncOrgRoles {
+				deleteOrgIds = append(deleteOrgIds, orga.OrgID)
+			}
 		} else if extRole != orga.Role {
 			// update role
 			cmd := &org.UpdateOrgUserCommand{OrgID: orga.OrgID, UserID: userID, Role: extRole}

--- a/pkg/services/authn/authnimpl/sync/org_sync_test.go
+++ b/pkg/services/authn/authnimpl/sync/org_sync_test.go
@@ -135,6 +135,127 @@ func TestOrgSync_SyncOrgRolesHook(t *testing.T) {
 	}
 }
 
+func TestOrgSync_SyncOrgRolesHook_Additive(t *testing.T) {
+	t.Run("additive mode: existing memberships preserved when syncing new org", func(t *testing.T) {
+		orgService := &orgtest.MockService{}
+		orgService.On("GetUserOrgList", mock.Anything, mock.Anything).Return([]*org.UserOrgDTO{
+			{OrgID: 1, Role: org.RoleAdmin},
+			{OrgID: 3, Role: org.RoleViewer},
+		}, nil)
+		// Expect add for org 2, no remove calls
+		orgService.On("AddOrgUser", mock.Anything, mock.MatchedBy(func(cmd *org.AddOrgUserCommand) bool {
+			return cmd.OrgID == 2 && cmd.UserID == 1 && cmd.Role == org.RoleEditor
+		})).Return(nil)
+
+		s := &OrgSync{
+			userService:   &usertest.FakeUserService{ExpectedUser: &user.User{ID: 1}},
+			orgService:    orgService,
+			accessControl: &actest.FakeService{},
+			log:           log.NewNopLogger(),
+			tracer:        tracing.InitializeTracerForTest(),
+		}
+
+		id := &authn.Identity{
+			ID:       "1",
+			Type:     claims.TypeUser,
+			OrgRoles: map[int64]identity.RoleType{2: org.RoleEditor},
+			ClientParams: authn.ClientParams{
+				SyncOrgRoles:         true,
+				AdditiveSyncOrgRoles: true,
+			},
+		}
+
+		err := s.SyncOrgRolesHook(context.Background(), id, nil)
+		assert.NoError(t, err)
+
+		// Must NOT have called RemoveOrgUser
+		orgService.AssertNotCalled(t, "RemoveOrgUser", mock.Anything, mock.Anything)
+		// Must have called AddOrgUser for org 2
+		orgService.AssertCalled(t, "AddOrgUser", mock.Anything, mock.MatchedBy(func(cmd *org.AddOrgUserCommand) bool {
+			return cmd.OrgID == 2
+		}))
+	})
+
+	t.Run("additive mode: role update in request org, others untouched", func(t *testing.T) {
+		orgService := &orgtest.MockService{}
+		orgService.On("GetUserOrgList", mock.Anything, mock.Anything).Return([]*org.UserOrgDTO{
+			{OrgID: 1, Role: org.RoleAdmin},
+			{OrgID: 2, Role: org.RoleViewer},
+		}, nil)
+		orgService.On("UpdateOrgUser", mock.Anything, mock.MatchedBy(func(cmd *org.UpdateOrgUserCommand) bool {
+			return cmd.OrgID == 2 && cmd.UserID == 1 && cmd.Role == org.RoleEditor
+		})).Return(nil)
+
+		s := &OrgSync{
+			userService:   &usertest.FakeUserService{ExpectedUser: &user.User{ID: 1}},
+			orgService:    orgService,
+			accessControl: &actest.FakeService{},
+			log:           log.NewNopLogger(),
+			tracer:        tracing.InitializeTracerForTest(),
+		}
+
+		id := &authn.Identity{
+			ID:       "1",
+			Type:     claims.TypeUser,
+			OrgRoles: map[int64]identity.RoleType{2: org.RoleEditor},
+			ClientParams: authn.ClientParams{
+				SyncOrgRoles:         true,
+				AdditiveSyncOrgRoles: true,
+			},
+		}
+
+		err := s.SyncOrgRolesHook(context.Background(), id, nil)
+		assert.NoError(t, err)
+
+		orgService.AssertNotCalled(t, "RemoveOrgUser", mock.Anything, mock.Anything)
+		orgService.AssertCalled(t, "UpdateOrgUser", mock.Anything, mock.MatchedBy(func(cmd *org.UpdateOrgUserCommand) bool {
+			return cmd.OrgID == 2 && cmd.Role == org.RoleEditor
+		}))
+	})
+
+	t.Run("non-additive mode: memberships removed as before", func(t *testing.T) {
+		orgService := &orgtest.MockService{}
+		orgService.On("GetUserOrgList", mock.Anything, mock.Anything).Return([]*org.UserOrgDTO{
+			{OrgID: 1, Role: org.RoleAdmin},
+			{OrgID: 2, Role: org.RoleViewer},
+		}, nil)
+		orgService.On("UpdateOrgUser", mock.Anything, mock.MatchedBy(func(cmd *org.UpdateOrgUserCommand) bool {
+			return cmd.OrgID == 2 && cmd.UserID == 1 && cmd.Role == org.RoleEditor
+		})).Return(nil)
+		orgService.On("RemoveOrgUser", mock.Anything, mock.MatchedBy(func(cmd *org.RemoveOrgUserCommand) bool {
+			return cmd.OrgID == 1 && cmd.UserID == 1
+		})).Return(nil)
+
+		acService := &actest.FakeService{}
+
+		s := &OrgSync{
+			userService:   &usertest.FakeUserService{ExpectedUser: &user.User{ID: 1}},
+			orgService:    orgService,
+			accessControl: acService,
+			log:           log.NewNopLogger(),
+			tracer:        tracing.InitializeTracerForTest(),
+		}
+
+		id := &authn.Identity{
+			ID:       "1",
+			Type:     claims.TypeUser,
+			OrgRoles: map[int64]identity.RoleType{2: org.RoleEditor},
+			ClientParams: authn.ClientParams{
+				SyncOrgRoles:         true,
+				AdditiveSyncOrgRoles: false,
+			},
+		}
+
+		err := s.SyncOrgRolesHook(context.Background(), id, nil)
+		assert.NoError(t, err)
+
+		// org1 membership should be removed
+		orgService.AssertCalled(t, "RemoveOrgUser", mock.Anything, mock.MatchedBy(func(cmd *org.RemoveOrgUserCommand) bool {
+			return cmd.OrgID == 1
+		}))
+	})
+}
+
 func TestOrgSync_SetDefaultOrgHook(t *testing.T) {
 	testCases := []struct {
 		name              string

--- a/pkg/services/authn/clients/grafana.go
+++ b/pkg/services/authn/clients/grafana.go
@@ -43,12 +43,13 @@ func (c *Grafana) AuthenticateProxy(ctx context.Context, r *authn.Request, usern
 		AuthenticatedBy: login.AuthProxyAuthModule,
 		AuthID:          username,
 		ClientParams: authn.ClientParams{
-			SyncUser:        true,
-			SyncTeams:       true,
-			FetchSyncedUser: true,
-			SyncOrgRoles:    true,
-			SyncPermissions: true,
-			AllowSignUp:     c.cfg.AuthProxy.AutoSignUp,
+			SyncUser:             true,
+			SyncTeams:            true,
+			FetchSyncedUser:      true,
+			SyncOrgRoles:         true,
+			AdditiveSyncOrgRoles: true,
+			SyncPermissions:      true,
+			AllowSignUp:          c.cfg.AuthProxy.AutoSignUp,
 		},
 	}
 
@@ -79,7 +80,7 @@ func (c *Grafana) AuthenticateProxy(ctx context.Context, r *authn.Request, usern
 	}
 
 	if v, ok := additional[proxyFieldRole]; ok {
-		orgRoles, isGrafanaAdmin, _ := getRoles(c.cfg, func() (org.RoleType, *bool, error) {
+		orgRoles, isGrafanaAdmin, _ := getRolesForOrg(c.cfg, r.OrgID, func() (org.RoleType, *bool, error) {
 			return org.RoleType(v), nil, nil
 		})
 		identity.OrgRoles = orgRoles

--- a/pkg/services/authn/clients/grafana_test.go
+++ b/pkg/services/authn/clients/grafana_test.go
@@ -50,14 +50,43 @@ func TestGrafana_AuthenticateProxy(t *testing.T) {
 				AuthID:          "test",
 				Groups:          []string{"grp1", "grp2"},
 				ClientParams: authn.ClientParams{
-					SyncUser:        true,
-					SyncTeams:       true,
-					AllowSignUp:     true,
-					FetchSyncedUser: true,
-					SyncOrgRoles:    true,
+					SyncUser:             true,
+					SyncTeams:            true,
+					AllowSignUp:          true,
+					FetchSyncedUser:      true,
+					SyncOrgRoles:         true,
+					AdditiveSyncOrgRoles: true,
 					LookUpParams: login.UserLookupParams{
 						Email: strPtr("email@email.com"),
 						Login: strPtr("test"),
+					},
+				},
+			},
+		},
+		{
+			desc:     "should map role to request org when org header is set",
+			username: "test@test.com",
+			req:      &authn.Request{OrgID: 42, HTTPRequest: &http.Request{Header: map[string][]string{}}},
+			additional: map[string]string{
+				proxyFieldRole: "Editor",
+			},
+			proxyProperty: "email",
+			expectedIdentity: &authn.Identity{
+				OrgRoles:        map[int64]org.RoleType{42: org.RoleEditor},
+				Login:           "test@test.com",
+				Email:           "test@test.com",
+				AuthenticatedBy: login.AuthProxyAuthModule,
+				AuthID:          "test@test.com",
+				ClientParams: authn.ClientParams{
+					SyncUser:             true,
+					SyncTeams:            true,
+					AllowSignUp:          true,
+					FetchSyncedUser:      true,
+					SyncOrgRoles:         true,
+					AdditiveSyncOrgRoles: true,
+					LookUpParams: login.UserLookupParams{
+						Email: strPtr("test@test.com"),
+						Login: strPtr("test@test.com"),
 					},
 				},
 			},
@@ -73,10 +102,11 @@ func TestGrafana_AuthenticateProxy(t *testing.T) {
 				AuthenticatedBy: login.AuthProxyAuthModule,
 				AuthID:          "test@test.com",
 				ClientParams: authn.ClientParams{
-					SyncUser:     true,
-					SyncTeams:    true,
-					AllowSignUp:  true,
-					SyncOrgRoles: true,
+					SyncUser:             true,
+					SyncTeams:            true,
+					AllowSignUp:          true,
+					SyncOrgRoles:         true,
+					AdditiveSyncOrgRoles: true,
 					LookUpParams: login.UserLookupParams{
 						Email: strPtr("test@test.com"),
 						Login: strPtr("test@test.com"),
@@ -114,6 +144,7 @@ func TestGrafana_AuthenticateProxy(t *testing.T) {
 				assert.Equal(t, tt.expectedIdentity.ClientParams.SyncUser, identity.ClientParams.SyncUser)
 				assert.Equal(t, tt.expectedIdentity.ClientParams.AllowSignUp, identity.ClientParams.AllowSignUp)
 				assert.Equal(t, tt.expectedIdentity.ClientParams.SyncTeams, identity.ClientParams.SyncTeams)
+				assert.Equal(t, tt.expectedIdentity.ClientParams.AdditiveSyncOrgRoles, identity.ClientParams.AdditiveSyncOrgRoles)
 				assert.Equal(t, tt.expectedIdentity.ClientParams.EnableUser, identity.ClientParams.EnableUser)
 
 				assert.EqualValues(t, tt.expectedIdentity.ClientParams.LookUpParams.Email, identity.ClientParams.LookUpParams.Email)

--- a/pkg/services/authn/clients/utils.go
+++ b/pkg/services/authn/clients/utils.go
@@ -24,3 +24,25 @@ func getRoles(cfg *setting.Cfg, extract roleExtractor) (map[int64]org.RoleType, 
 
 	return orgRoles, isGrafanaAdmin, nil
 }
+
+// getRolesForOrg maps the extracted role to requestOrgID if > 0,
+// otherwise falls back to cfg.DefaultOrgID().
+func getRolesForOrg(cfg *setting.Cfg, requestOrgID int64, extract roleExtractor) (map[int64]org.RoleType, *bool, error) {
+	role, isGrafanaAdmin, err := extract()
+	orgRoles := make(map[int64]org.RoleType, 0)
+	if err != nil {
+		return orgRoles, nil, err
+	}
+
+	if role == "" || !role.IsValid() {
+		return orgRoles, nil, nil
+	}
+
+	targetOrgID := requestOrgID
+	if targetOrgID <= 0 {
+		targetOrgID = cfg.DefaultOrgID()
+	}
+	orgRoles[targetOrgID] = role
+
+	return orgRoles, isGrafanaAdmin, nil
+}

--- a/pkg/services/authn/clients/utils_test.go
+++ b/pkg/services/authn/clients/utils_test.go
@@ -1,0 +1,47 @@
+package clients
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func TestGetRolesForOrg(t *testing.T) {
+	cfg := setting.NewCfg()
+	// default org id is 1
+
+	t.Run("valid role with request org > 0 maps to request org", func(t *testing.T) {
+		orgRoles, _, err := getRolesForOrg(cfg, 42, func() (org.RoleType, *bool, error) {
+			return org.RoleEditor, nil, nil
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, map[int64]org.RoleType{42: org.RoleEditor}, orgRoles)
+	})
+
+	t.Run("valid role with request org <= 0 falls back to default org", func(t *testing.T) {
+		orgRoles, _, err := getRolesForOrg(cfg, 0, func() (org.RoleType, *bool, error) {
+			return org.RoleViewer, nil, nil
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, map[int64]org.RoleType{1: org.RoleViewer}, orgRoles)
+	})
+
+	t.Run("invalid role returns empty map", func(t *testing.T) {
+		orgRoles, _, err := getRolesForOrg(cfg, 42, func() (org.RoleType, *bool, error) {
+			return org.RoleType("invalid"), nil, nil
+		})
+		assert.NoError(t, err)
+		assert.Empty(t, orgRoles)
+	})
+
+	t.Run("empty role returns empty map", func(t *testing.T) {
+		orgRoles, _, err := getRolesForOrg(cfg, 42, func() (org.RoleType, *bool, error) {
+			return "", nil, nil
+		})
+		assert.NoError(t, err)
+		assert.Empty(t, orgRoles)
+	})
+}


### PR DESCRIPTION
Ref D-6951

When `GF_AUTH_PROXY_AUTO_SIGN_UP` and
`GF_AUTH_PROXY_ENABLED` are set, Grafana
automatically creates users if necessary,
and syncs roles with DB based on header values.

However, the (user, role, org) tuple was always
created in the default org, and the `X-Grafana-Org-Id`
header was ignored.

We fix that in this change.

Also, previously, as part of org-sync, this was the
behavior:
 - headers: user1, role1, org1
 - org-sync: create user1 if needed, store (user1, role1, org1)
 - headers: user1, role2, org2
 - org-sync: delete (user1, role1, org1) and store (user1, role2, org2)

This behavior causes unnecessary churn in the DB when there
are users that can be part of more than one org. Here, we fix
the churn by not deleting any (user, role, org) tuples of
unrelated orgs.

### Test Plan
New UTs
