### PR TITLE
feat: stop swallowing "value not allowed" errors

### DIFF
--- a/apps/dashboard/pkg/apis/dashboard/cuevalidator/format.go
+++ b/apps/dashboard/pkg/apis/dashboard/cuevalidator/format.go
@@ -1,0 +1,164 @@
+package cuevalidator
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	cueerrors "cuelang.org/go/cue/errors"
+)
+
+// FormattedError is a single validation error extracted from CUE's raw
+// error tree. Callers translate FormattedError.Path into whatever shape
+// their public API expects (for example a Kubernetes field.Path with
+// the schema prefix stripped).
+type FormattedError struct {
+	// Path is the raw CUE path of the offending field.
+	Path []string
+	// Message is a single-line, caller-friendly description of the
+	// failure.
+	Message string
+}
+
+// Format-string identifiers used by the CUE evaluator. Each kind of
+// error CUE emits carries a stable format string (the literal passed
+// to its error constructor) which we use as a discriminator. Matching
+// on the identifier is robust to changes in the rendered message
+// because the constants themselves are what CUE compares against
+// internally when building the error.
+//
+// If CUE ever changes a format string in a new release, the
+// TestFormatStringsAreStable test below fails loudly, with a one-line
+// fix: update the constant.
+const (
+	// "N errors in empty disjunction:" — a synthetic wrapper emitted
+	// alongside per-arm child errors. Carries no information beyond
+	// what its children carry.
+	emptyDisjunctionFmt = "%d errors in empty disjunction:"
+
+	// `conflicting values "thresholds" and "continuous-BlGrOr"`
+	// — what CUE emits per arm of a string-literal disjunction (also
+	// per arm of struct disjunctions, but in that case args[0] is
+	// typically a struct value, not a string, so we don't mis-match).
+	conflictingValuesFmt = "conflicting values %s and %s"
+)
+
+// FormatErrors converts a raw CUE validation error into a list of
+// caller-friendly errors. It performs two structural transformations
+// and otherwise leaves CUE errors alone:
+//
+//  1. Drops the synthetic "N errors in empty disjunction:" wrapper.
+//     The wrapper carries no information beyond the per-arm child
+//     errors, so on its own it is just noise.
+//
+//  2. Consolidates per-arm "conflicting values" errors. When a string
+//     value fails one arm of a string-literal disjunction, CUE emits
+//     one error per arm. We bucket these by path, verify they all
+//     share the same actual (right-hand) value, and emit a single
+//     `"X" is not one of [A, B, …]` message listing the allowed arms
+//     in sorted order. This collapses fifteen "conflicting values"
+//     lines for a typo'd FieldColorModeId into one.
+//
+// Errors that don't match either of those patterns — type mismatches,
+// "field not allowed", missing required fields, struct-arm disjunction
+// failures whose args aren't both strings — pass through unchanged.
+//
+// Detection is structural: we discriminate on the error's format
+// string (a stable identifier inside CUE's error constructors) and
+// read the already-typed Msg() args, rather than parsing the rendered
+// message text.
+func FormatErrors(err error) []FormattedError {
+	if err == nil {
+		return nil
+	}
+
+	// A bucket collects everything CUE reported at a single path so
+	// we can consolidate the string-enum subset.
+	type bucket struct {
+		order   int
+		path    []string
+		actual  string           // shared RHS across enum-arm errors
+		allowed []string         // collected LHS values (one per arm)
+		passes  []FormattedError // anything we couldn't consolidate
+	}
+	buckets := map[string]*bucket{}
+	keyOf := func(p []string) string { return strings.Join(p, "\x00") }
+	order := 0
+
+	for _, e := range cueerrors.Errors(err) {
+		format, args := e.Msg()
+
+		// Drop the synthetic wrapper unconditionally.
+		if format == emptyDisjunctionFmt {
+			continue
+		}
+
+		path := append([]string(nil), e.Path()...)
+		key := keyOf(path)
+		b, ok := buckets[key]
+		if !ok {
+			b = &bucket{order: order, path: path}
+			buckets[key] = b
+			order++
+		}
+
+		// Detect a string-enum arm error structurally: same format
+		// string, two args, both already typed as plain Go strings.
+		// CUE's string-arg formatting includes the surrounding quotes
+		// in the value, so the strings look like `"thresholds"` —
+		// preserve that exactly in the consolidated output so it
+		// matches what the caller would otherwise have seen.
+		if format == conflictingValuesFmt && len(args) == 2 {
+			lhs, lok := args[0].(string)
+			rhs, rok := args[1].(string)
+			if lok && rok {
+				if b.actual == "" {
+					b.actual = rhs
+				}
+				if b.actual == rhs {
+					b.allowed = append(b.allowed, lhs)
+					continue
+				}
+			}
+		}
+
+		// Anything else: pass through verbatim, using CUE's own
+		// rendering of the format + args.
+		b.passes = append(b.passes, FormattedError{
+			Path:    path,
+			Message: fmt.Sprintf(format, args...),
+		})
+	}
+
+	ordered := make([]*bucket, 0, len(buckets))
+	for _, b := range buckets {
+		ordered = append(ordered, b)
+	}
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].order < ordered[j].order })
+
+	out := make([]FormattedError, 0)
+	for _, b := range ordered {
+		if len(b.allowed) > 0 {
+			seen := make(map[string]struct{}, len(b.allowed))
+			uniq := make([]string, 0, len(b.allowed))
+			for _, v := range b.allowed {
+				if _, dup := seen[v]; dup {
+					continue
+				}
+				seen[v] = struct{}{}
+				uniq = append(uniq, v)
+			}
+			sort.Strings(uniq)
+			out = append(out, FormattedError{
+				Path: b.path,
+				Message: fmt.Sprintf(
+					"%s is not one of [%s]",
+					b.actual,
+					strings.Join(uniq, ", "),
+				),
+			})
+		}
+		out = append(out, b.passes...)
+	}
+	return out
+}

--- a/apps/dashboard/pkg/apis/dashboard/cuevalidator/format_test.go
+++ b/apps/dashboard/pkg/apis/dashboard/cuevalidator/format_test.go
@@ -1,0 +1,223 @@
+package cuevalidator_test
+
+import (
+	"strings"
+	"testing"
+
+	"cuelang.org/go/cue/cuecontext"
+	cueerrors "cuelang.org/go/cue/errors"
+	cuejson "cuelang.org/go/encoding/json"
+
+	"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/cuevalidator"
+)
+
+// validate compiles a CUE schema and validates a JSON literal against
+// it. Inline rather than using the production cuevalidator.Validator
+// so these tests don't depend on the real dashboard schemas and stay
+// fast.
+func validate(t *testing.T, schema, jsonValue string) error {
+	t.Helper()
+	ctx := cuecontext.New()
+	compiled := ctx.CompileString(schema)
+	if compiled.Err() != nil {
+		t.Fatalf("compile schema: %v", compiled.Err())
+	}
+	return cuejson.Validate([]byte(jsonValue), compiled)
+}
+
+func TestFormatErrors_NilError(t *testing.T) {
+	if got := cuevalidator.FormatErrors(nil); got != nil {
+		t.Fatalf("expected nil, got %v", got)
+	}
+}
+
+// TestFormatStringsAreStable pins the CUE-internal format string
+// identifiers FormatErrors uses to discriminate error kinds. The
+// implementation matches on these identifiers (not on the rendered
+// message text), so if a future CUE release changes the wording, this
+// test fails with a one-line fix: update the constants in format.go.
+//
+// Without this test, a CUE format-string change would silently turn
+// consolidation off again and reintroduce the "fifteen errors per
+// typo'd color mode" failure mode.
+func TestFormatStringsAreStable(t *testing.T) {
+	err := validate(t, `mode: "a" | "b"`, `{"mode": "z"}`)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+
+	var sawWrapper, sawArm bool
+	for _, e := range cueerrors.Errors(err) {
+		format, _ := e.Msg()
+		switch format {
+		case "%d errors in empty disjunction:":
+			sawWrapper = true
+		case "conflicting values %s and %s":
+			sawArm = true
+		}
+	}
+	if !sawWrapper {
+		t.Errorf("expected CUE to still emit a \"%%d errors in empty disjunction:\" wrapper; if you're updating CUE, sync the constant in format.go")
+	}
+	if !sawArm {
+		t.Errorf("expected CUE to still emit \"conflicting values %%s and %%s\" per arm; if you're updating CUE, sync the constant in format.go")
+	}
+}
+
+// TestFormatErrors_ConsolidatesStringEnumDisjunction is the headline
+// behavioural contract: a typo'd string-literal enum value collapses
+// from N per-arm errors into one clean `"X" is not one of [...]`
+// message naming the offending value and listing every allowed arm
+// in sorted order.
+func TestFormatErrors_ConsolidatesStringEnumDisjunction(t *testing.T) {
+	err := validate(t, `mode: "a" | "b" | "c"`, `{"mode": "z"}`)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	out := cuevalidator.FormatErrors(err)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 consolidated error, got %d: %#v", len(out), out)
+	}
+
+	msg := out[0].Message
+	if !strings.Contains(msg, `"z" is not one of`) {
+		t.Errorf("message %q should name the offending value", msg)
+	}
+	for _, want := range []string{`"a"`, `"b"`, `"c"`} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message %q should list allowed literal %s", msg, want)
+		}
+	}
+	// Sorted order: the allowed set should be deterministic regardless
+	// of the order CUE emitted the per-arm errors.
+	wantInOrder := `"a", "b", "c"`
+	if !strings.Contains(msg, wantInOrder) {
+		t.Errorf("message %q should list allowed values in sorted order (%s)", msg, wantInOrder)
+	}
+	// No leak of CUE internals.
+	if strings.Contains(msg, "disjunction") {
+		t.Errorf("message %q should not mention CUE internals", msg)
+	}
+	if strings.Contains(msg, "conflicting values") {
+		t.Errorf("message %q should not contain raw per-arm errors", msg)
+	}
+}
+
+// TestFormatErrors_PreservesFieldNotAllowed pins the post-fix
+// behaviour for typo'd or unknown fields. Earlier versions of this
+// helper silently dropped these (so typo'd properties like
+// `transformatons` were invisible to callers); they must now reach
+// the API verbatim.
+func TestFormatErrors_PreservesFieldNotAllowed(t *testing.T) {
+	err := validate(t, `close({ allowed: string })`, `{"allowed": "ok", "unexpected": "x"}`)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	out := cuevalidator.FormatErrors(err)
+
+	found := false
+	for _, fe := range out {
+		if strings.Contains(fe.Message, "field not allowed") {
+			found = true
+			if len(fe.Path) == 0 || fe.Path[len(fe.Path)-1] != "unexpected" {
+				t.Errorf("expected path to end in 'unexpected', got %v", fe.Path)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("field-not-allowed error should pass through; got %v", out)
+	}
+}
+
+// TestFormatErrors_PreservesTypeMismatch guards against the
+// consolidation logic accidentally collapsing type-mismatch errors,
+// which use a different CUE format string from enum-arm errors but
+// could easily be mis-matched by a careless implementation.
+func TestFormatErrors_PreservesTypeMismatch(t *testing.T) {
+	err := validate(t, `value: [...string]`, `{"value": "not-a-list"}`)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	out := cuevalidator.FormatErrors(err)
+	if len(out) == 0 {
+		t.Fatal("expected at least one error")
+	}
+	found := false
+	for _, fe := range out {
+		if strings.Contains(fe.Message, "mismatched types") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("type mismatch should pass through verbatim; got %v", out)
+	}
+}
+
+// TestFormatErrors_DropsSyntheticDisjunctionWrapper confirms the
+// "%d errors in empty disjunction:" wrapper never reaches callers.
+// (Its child errors carry the actual information; the wrapper is
+// pure noise.)
+func TestFormatErrors_DropsSyntheticDisjunctionWrapper(t *testing.T) {
+	err := validate(t, `mode: "a" | "b"`, `{"mode": "z"}`)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	out := cuevalidator.FormatErrors(err)
+	for _, fe := range out {
+		if strings.Contains(fe.Message, "empty disjunction") {
+			t.Errorf("wrapper should be dropped, but got: %q", fe.Message)
+		}
+	}
+}
+
+// TestFormatErrors_PreservesPath confirms the helper doesn't rewrite
+// or truncate the CUE path — callers depend on the full path for
+// their own prefix stripping.
+func TestFormatErrors_PreservesPath(t *testing.T) {
+	err := validate(t,
+		`outer: { inner: { mode: "a" | "b" } }`,
+		`{"outer": {"inner": {"mode": "z"}}}`,
+	)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	out := cuevalidator.FormatErrors(err)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 consolidated error, got %d: %#v", len(out), out)
+	}
+	wantSuffix := []string{"outer", "inner", "mode"}
+	got := out[0].Path
+	if len(got) < len(wantSuffix) {
+		t.Fatalf("path %v shorter than expected suffix %v", got, wantSuffix)
+	}
+	tail := got[len(got)-len(wantSuffix):]
+	for i := range wantSuffix {
+		if tail[i] != wantSuffix[i] {
+			t.Errorf("path tail %v != %v", tail, wantSuffix)
+			break
+		}
+	}
+}
+
+// TestFormatErrors_DeduplicatesAllowedSet ensures the allowed-arm
+// list is unique even when CUE reports the same arm via multiple
+// unification branches.
+func TestFormatErrors_DeduplicatesAllowedSet(t *testing.T) {
+	err := validate(t,
+		`mode: ("a" | "b") & ("a" | "c")`,
+		`{"mode": "z"}`,
+	)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	out := cuevalidator.FormatErrors(err)
+	if len(out) == 0 {
+		t.Fatal("expected at least one error")
+	}
+	msg := out[0].Message
+	for _, lit := range []string{`"a"`, `"b"`, `"c"`} {
+		if n := strings.Count(msg, lit); n > 1 {
+			t.Errorf("literal %s appears %d times in %q; want at most 1", lit, n, msg)
+		}
+	}
+}

--- a/apps/dashboard/pkg/apis/dashboard/v0alpha1/validation.go
+++ b/apps/dashboard/pkg/apis/dashboard/v0alpha1/validation.go
@@ -13,7 +13,6 @@ import (
 
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/cuecontext"
-	"cuelang.org/go/cue/errors"
 )
 
 func ValidateDashboardSpec(obj *Dashboard, forceValidation bool) (field.ErrorList, field.ErrorList) {
@@ -34,31 +33,15 @@ func ValidateDashboardSpec(obj *Dashboard, forceValidation bool) (field.ErrorLis
 	}
 
 	if err := getValidator().Validate(data); err != nil {
-		errs := field.ErrorList{}
-
-		for _, e := range errors.Errors(err) {
-			if
-			// We don't want to return confusing "empty disjunction" errors,
-			// because the users don't necessarily understand what to do with them.
-			// For empty disjunctions, CUE will also return more specific errors,
-			// so we can safely ignore the generic ones.
-			strings.Contains(e.Error(), "disjunction") ||
-				// We don't want to return errors about unknown fields either.
-				strings.Contains(e.Error(), "field not allowed") {
-				continue
-			}
-
-			// We want to manually format the error message,
-			// because e.Error() contains the full CUE path.
-			format, args := e.Msg()
-
+		formatted := cuevalidator.FormatErrors(err)
+		errs := make(field.ErrorList, 0, len(formatted))
+		for _, fe := range formatted {
 			errs = append(errs, field.Invalid(
-				field.NewPath(formatErrorPath(e.Path())),
+				field.NewPath(formatErrorPath(fe.Path)),
 				field.OmitValueType{},
-				fmt.Sprintf(format, args...),
+				fe.Message,
 			))
 		}
-
 		return errs, schemaVersionError
 	}
 

--- a/apps/dashboard/pkg/apis/dashboard/v1beta1/validation.go
+++ b/apps/dashboard/pkg/apis/dashboard/v1beta1/validation.go
@@ -11,7 +11,6 @@ import (
 
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/cuecontext"
-	"cuelang.org/go/cue/errors"
 
 	"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/cuevalidator"
 	"github.com/grafana/grafana/apps/dashboard/pkg/migration/schemaversion"
@@ -35,31 +34,15 @@ func ValidateDashboardSpec(obj *Dashboard, forceValidation bool) (field.ErrorLis
 	}
 
 	if err := getValidator().Validate(data); err != nil {
-		errs := field.ErrorList{}
-
-		for _, e := range errors.Errors(err) {
-			if
-			// We don't want to return confusing "empty disjunction" errors,
-			// because the users don't necessarily understand what to do with them.
-			// For empty disjunctions, CUE will also return more specific errors,
-			// so we can safely ignore the generic ones.
-			strings.Contains(e.Error(), "disjunction") ||
-				// We don't want to return errors about unknown fields either.
-				strings.Contains(e.Error(), "field not allowed") {
-				continue
-			}
-
-			// We want to manually format the error message,
-			// because e.Error() contains the full CUE path.
-			format, args := e.Msg()
-
+		formatted := cuevalidator.FormatErrors(err)
+		errs := make(field.ErrorList, 0, len(formatted))
+		for _, fe := range formatted {
 			errs = append(errs, field.Invalid(
-				field.NewPath(formatErrorPath(e.Path())),
+				field.NewPath(formatErrorPath(fe.Path)),
 				field.OmitValueType{},
-				fmt.Sprintf(format, args...),
+				fe.Message,
 			))
 		}
-
 		return errs, schemaVersionError
 	}
 

--- a/apps/dashboard/pkg/apis/dashboard/v1beta1/validation_test.go
+++ b/apps/dashboard/pkg/apis/dashboard/v1beta1/validation_test.go
@@ -1,0 +1,202 @@
+package v1beta1
+
+import (
+	"strings"
+	"testing"
+
+	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
+)
+
+func makeDashboard(spec map[string]any) *Dashboard {
+	return &Dashboard{
+		Spec: DashboardSpec{Object: spec},
+	}
+}
+
+func panelSpec(overrides map[string]any) map[string]any {
+	p := map[string]any{
+		"id":      float64(1),
+		"type":    "timeseries",
+		"title":   "p",
+		"gridPos": map[string]any{"h": float64(8), "w": float64(12), "x": float64(0), "y": float64(0)},
+	}
+	for k, v := range overrides {
+		p[k] = v
+	}
+	return p
+}
+
+// TestValidateDashboardSpec_ColorModeEnum is the regression test for
+// the original bug: a typo'd FieldColorModeId used to be surfaced as
+// fifteen per-arm "conflicting values" errors. With the structural
+// consolidation in cuevalidator.FormatErrors, the API now returns a
+// single error that names the offending value and lists every
+// allowed alternative in sorted order — the exact shape an LLM or
+// human caller needs to fix the dashboard JSON in one round-trip.
+func TestValidateDashboardSpec_ColorModeEnum(t *testing.T) {
+	spec := map[string]any{
+		"schemaVersion": float64(42),
+		"title":         "Test",
+		"panels": []any{
+			panelSpec(map[string]any{
+				"fieldConfig": map[string]any{
+					"defaults": map[string]any{
+						"color": map[string]any{
+							"mode": "continuous-BlGrOr",
+						},
+					},
+					"overrides": []any{},
+				},
+			}),
+		},
+	}
+
+	errs, versionErr := ValidateDashboardSpec(makeDashboard(spec), false)
+	if versionErr != nil {
+		t.Fatalf("unexpected schema version error: %v", versionErr)
+	}
+
+	var colorErrors int
+	var colorMsg string
+	for _, fe := range errs {
+		if strings.HasSuffix(fe.Field, "color.mode") {
+			colorErrors++
+			colorMsg = fe.Detail
+		}
+	}
+
+	// Exactly one consolidated error, not one per arm.
+	if colorErrors != 1 {
+		t.Fatalf("expected 1 consolidated error at color.mode, got %d: %v", colorErrors, errs)
+	}
+
+	if !strings.Contains(colorMsg, `"continuous-BlGrOr"`) {
+		t.Errorf("error %q should name the offending value", colorMsg)
+	}
+	if !strings.Contains(colorMsg, "is not one of") {
+		t.Errorf("error %q should be the consolidated form", colorMsg)
+	}
+	for _, allowed := range []string{
+		"thresholds", "palette-classic", "palette-classic-by-name",
+		"continuous-GrYlRd", "continuous-RdYlGr", "continuous-BlYlRd",
+		"continuous-YlRd", "continuous-BlPu", "continuous-YlBl",
+		"continuous-blues", "continuous-reds", "continuous-greens",
+		"continuous-purples", "fixed", "shades",
+	} {
+		if !strings.Contains(colorMsg, allowed) {
+			t.Errorf("error %q should list allowed value %q", colorMsg, allowed)
+		}
+	}
+	if strings.Contains(colorMsg, "disjunction") {
+		t.Errorf("error %q should not leak CUE internals", colorMsg)
+	}
+	if strings.Contains(colorMsg, "conflicting values") {
+		t.Errorf("error %q should not contain raw per-arm errors", colorMsg)
+	}
+}
+
+// TestValidateDashboardSpec_FieldNotAllowed pins the post-fix
+// behaviour for typo'd or unknown fields. Previously these were
+// silently dropped, so users could mis-name a property (e.g.
+// `transformatons` instead of `transformations`) and only discover
+// it at render time. Now closed-struct violations surface as proper
+// API errors.
+func TestValidateDashboardSpec_FieldNotAllowed(t *testing.T) {
+	spec := map[string]any{
+		"schemaVersion": float64(42),
+		"title":         "Test",
+		"panels": []any{
+			panelSpec(map[string]any{
+				"obviouslyMadeUpProperty": "x",
+			}),
+		},
+	}
+	errs, _ := ValidateDashboardSpec(makeDashboard(spec), false)
+	if len(errs) == 0 {
+		t.Fatal("expected at least one error for unknown field")
+	}
+	found := false
+	for _, fe := range errs {
+		if strings.Contains(fe.Detail, "field not allowed") &&
+			strings.HasSuffix(fe.Field, "obviouslyMadeUpProperty") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a 'field not allowed' error for the unknown property; got %v", errs)
+	}
+}
+
+// TestValidateDashboardSpec_TypeMismatch confirms that errors which
+// are not enum-style disjunctions (here, a string where the schema
+// requires a list) surface verbatim with the offending path. The
+// consolidation logic uses CUE's format-string identifier as its
+// discriminator, so it must not collapse type-mismatch errors that
+// look superficially similar to enum-arm errors.
+func TestValidateDashboardSpec_TypeMismatch(t *testing.T) {
+	spec := map[string]any{
+		"schemaVersion": float64(42),
+		"title":         "x",
+		"panels":        "this-should-be-a-list",
+	}
+	errs, _ := ValidateDashboardSpec(makeDashboard(spec), false)
+	if len(errs) == 0 {
+		t.Fatal("expected at least one validation error")
+	}
+	found := false
+	for _, fe := range errs {
+		if strings.HasSuffix(fe.Field, "panels") &&
+			strings.Contains(fe.Detail, "mismatched types") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a type-mismatch error on panels; got %v", errs)
+	}
+}
+
+// TestValidateDashboardSpec_HappyPath_ColorMode guards against the
+// validator surfacing spurious errors for a perfectly valid dashboard.
+func TestValidateDashboardSpec_HappyPath_ColorMode(t *testing.T) {
+	spec := map[string]any{
+		"schemaVersion": float64(42),
+		"title":         "Test",
+		"panels": []any{
+			panelSpec(map[string]any{
+				"fieldConfig": map[string]any{
+					"defaults": map[string]any{
+						"color": map[string]any{
+							"mode": "continuous-GrYlRd",
+						},
+					},
+					"overrides": []any{},
+				},
+			}),
+		},
+	}
+	errs, _ := ValidateDashboardSpec(makeDashboard(spec), false)
+	for _, fe := range errs {
+		if strings.HasSuffix(fe.Field, "color.mode") {
+			t.Errorf("expected no color.mode error; got %v", fe)
+		}
+	}
+}
+
+// TestValidateDashboardSpec_SchemaVersion pins the schemaVersion
+// short-circuit: too-old versions return a single dedicated error
+// and skip CUE validation entirely.
+func TestValidateDashboardSpec_SchemaVersion(t *testing.T) {
+	spec := map[string]any{
+		"schemaVersion": float64(1),
+		"title":         "Test",
+	}
+	errs, versionErr := ValidateDashboardSpec(makeDashboard(spec), false)
+	if versionErr == nil {
+		t.Fatal("expected schemaVersion error")
+	}
+	if len(errs) != 0 {
+		t.Errorf("CUE errors should be skipped when schema version is too old; got %v", errs)
+	}
+}
+
+var _ = common.Unstructured{}

--- a/apps/dashboard/pkg/apis/dashboard/v2alpha1/validation.go
+++ b/apps/dashboard/pkg/apis/dashboard/v2alpha1/validation.go
@@ -3,7 +3,6 @@ package v2alpha1
 import (
 	_ "embed"
 	json "encoding/json"
-	fmt "fmt"
 	"strings"
 	"sync"
 
@@ -11,7 +10,6 @@ import (
 
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/cuecontext"
-	"cuelang.org/go/cue/errors"
 
 	"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/cuevalidator"
 )
@@ -28,36 +26,21 @@ func ValidateDashboardSpec(obj *Dashboard) field.ErrorList {
 	validateAndTrimActionArrays(obj)
 
 	if err := getValidator().Validate(data); err != nil {
-		errs := field.ErrorList{}
-
-		for _, e := range errors.Errors(err) {
-			if
-			// We don't want to return confusing "empty disjunction" errors,
-			// because the users don't necessarily understand what to do with them.
-			// For empty disjunctions, CUE will also return more specific errors,
-			// so we can safely ignore the generic ones.
-			strings.Contains(e.Error(), "disjunction") ||
-				// We don't want to return errors about unknown fields either.
-				strings.Contains(e.Error(), "field not allowed") {
+		formatted := cuevalidator.FormatErrors(err)
+		errs := make(field.ErrorList, 0, len(formatted))
+		for _, fe := range formatted {
+			// Go marshals empty slices as nil, which the CUE validator
+			// rejects as a type mismatch. This is a known false positive;
+			// drop it so it doesn't leak to API callers.
+			if strings.Contains(fe.Message, "mismatched types null and list") {
 				continue
 			}
-
-			if strings.Contains(e.Error(), "mismatched types null and list") {
-				// Go populates empty slices as nil, which the cue validator does not like
-				continue
-			}
-
-			// We want to manually format the error message,
-			// because e.Error() contains the full CUE path.
-			format, args := e.Msg()
-
 			errs = append(errs, field.Invalid(
-				field.NewPath(formatErrorPath(e.Path())),
+				field.NewPath(formatErrorPath(fe.Path)),
 				field.OmitValueType{},
-				fmt.Sprintf(format, args...),
+				fe.Message,
 			))
 		}
-
 		return errs
 	}
 

--- a/apps/dashboard/pkg/apis/dashboard/v2beta1/validation.go
+++ b/apps/dashboard/pkg/apis/dashboard/v2beta1/validation.go
@@ -3,7 +3,6 @@ package v2beta1
 import (
 	_ "embed"
 	json "encoding/json"
-	fmt "fmt"
 	"strings"
 	"sync"
 
@@ -11,7 +10,6 @@ import (
 
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/cuecontext"
-	"cuelang.org/go/cue/errors"
 
 	"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/cuevalidator"
 )
@@ -28,36 +26,21 @@ func ValidateDashboardSpec(obj *Dashboard) field.ErrorList {
 	validateAndTrimActionArrays(obj)
 
 	if err := getValidator().Validate(data); err != nil {
-		errs := field.ErrorList{}
-
-		for _, e := range errors.Errors(err) {
-			if
-			// We don't want to return confusing "empty disjunction" errors,
-			// because the users don't necessarily understand what to do with them.
-			// For empty disjunctions, CUE will also return more specific errors,
-			// so we can safely ignore the generic ones.
-			strings.Contains(e.Error(), "disjunction") ||
-				// We don't want to return errors about unknown fields either.
-				strings.Contains(e.Error(), "field not allowed") {
+		formatted := cuevalidator.FormatErrors(err)
+		errs := make(field.ErrorList, 0, len(formatted))
+		for _, fe := range formatted {
+			// Go marshals empty slices as nil, which the CUE validator
+			// rejects as a type mismatch. This is a known false positive;
+			// drop it so it doesn't leak to API callers.
+			if strings.Contains(fe.Message, "mismatched types null and list") {
 				continue
 			}
-
-			if strings.Contains(e.Error(), "mismatched types null and list") {
-				// Go populates empty slices as nil, which the cue validator does not like
-				continue
-			}
-
-			// We want to manually format the error message,
-			// because e.Error() contains the full CUE path.
-			format, args := e.Msg()
-
 			errs = append(errs, field.Invalid(
-				field.NewPath(formatErrorPath(e.Path())),
+				field.NewPath(formatErrorPath(fe.Path)),
 				field.OmitValueType{},
-				fmt.Sprintf(format, args...),
+				fe.Message,
 			))
 		}
-
 		return errs
 	}
 


### PR DESCRIPTION
Ref D-7069

Also, emit more readable errors for lack of Enum Membership:

Old
```
Issues:
spec.panels.0.fieldConfig.defaults.color.mode:
Invalid value: conflicting values "continuous-BlPu" and "continuous-BlGrOr";

spec.panels.0.fieldConfig.defaults.color.mode:
Invalid value: conflicting values "continuous-BlYlRd" and "continuous-BlGrOr";

spec.panels.0.fieldConfig.defaults.color.mode:
Invalid value: conflicting values "continuous-GrYlRd" and "continuous-BlGrOr";
<it goes on>
```

New:
```
Issues:
spec.panels.0.fieldConfig.defaults.color.mode:
Invalid value: "continuous-BlGrOr" is not one of
["continuous-BlPu", "continuous-BlYlRd", "continuous-GrYlRd", <it goes on>]
```

This does not affect any of the APIs that we use currently
because the validation is disabled for all those APIs anyway.

However this does give better errors if someone actually wants
to call the validation APIs.