### PR TITLE
feat: Print Dashboard (also, no more image export if no renderer)

### DIFF
--- a/packages/grafana-data/src/types/icon.ts
+++ b/packages/grafana-data/src/types/icon.ts
@@ -220,6 +220,7 @@ export const availableIconsIndex = {
   'plus-square': true,
   power: true,
   'presentation-play': true,
+  print: true,
   process: true,
   'question-circle': true,
   'record-audio': true,

--- a/packages/grafana-e2e-selectors/src/selectors/pages.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/pages.ts
@@ -238,6 +238,9 @@ export const versionedPages = {
           exportAsImage: {
             '12.1.0': 'data-testid new export button export as image',
           },
+          printDashboard: {
+            '12.3.0': 'data-testid new export button print dashboard',
+          },
           cloneDashboard: {
             '12.1.0': 'data-testid new export button clone dashboard',
           },

--- a/packages/grafana-ui/src/components/Portal/Portal.tsx
+++ b/packages/grafana-ui/src/components/Portal/Portal.tsx
@@ -70,6 +70,10 @@ const getStyles = (theme: GrafanaTheme2) => {
       top: 0,
       width: '100%',
       zIndex: theme.zIndex.portal,
+      '@media print': {
+        position: 'static',
+        zIndex: 'auto',
+      },
     }),
   };
 };

--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -193,6 +193,9 @@ const getStyles = (theme: GrafanaTheme2, headerHeight: number) => {
       paddingTop: headerHeight,
       flexGrow: 1,
       height: 'auto',
+      '@media print': {
+        paddingTop: 0,
+      },
     }),
     contentWithSidebar: css({
       height: '100vh',
@@ -232,6 +235,10 @@ const getStyles = (theme: GrafanaTheme2, headerHeight: number) => {
       right: 0,
       background: theme.colors.background.primary,
       flexDirection: 'column',
+      '@media print': {
+        position: 'static',
+        zIndex: 'auto',
+      },
     }),
     topNavMenuDocked: css({
       left: MENU_WIDTH,

--- a/public/app/core/components/AppNotifications/AppNotificationList.tsx
+++ b/public/app/core/components/AppNotifications/AppNotificationList.tsx
@@ -77,6 +77,11 @@ function getStyles(theme: GrafanaTheme2) {
       position: 'fixed',
       right: 6,
       top: 88,
+      '@media print': {
+        position: 'static',
+        right: 'auto',
+        top: 'auto',
+      },
     }),
   };
 }

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
@@ -193,6 +193,11 @@ function getStyles(theme: GrafanaTheme2, headerHeight: number) {
         background: theme.colors.background.canvas,
         top: headerHeight,
       },
+      '@media print': {
+        position: 'static',
+        zIndex: 'auto',
+        top: 'auto',
+      },
     }),
   };
 }

--- a/public/app/features/dashboard-scene/sharing/ExportButton/ExportMenu.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/ExportMenu.test.tsx
@@ -9,20 +9,34 @@ import { DefaultGridLayoutManager } from '../../scene/layout-default/DefaultGrid
 import ExportMenu from './ExportMenu';
 
 describe('ExportMenu', () => {
+  beforeEach(() => {
+    config.featureToggles.sharingDashboardImage = false;
+    config.rendererAvailable = false;
+  });
+
   it('should render menu items', async () => {
     setup();
     expect(await screen.findByRole('menuitem', { name: /export as json/i })).toBeInTheDocument();
   });
 
   describe('sharingDashboardImage feature toggle', () => {
-    it('should render image export option when enabled', async () => {
+    it('should render image export option when enabled and the image renderer is available', async () => {
       config.featureToggles.sharingDashboardImage = true;
+      config.rendererAvailable = true;
       setup();
       expect(await screen.findByRole('menuitem', { name: /export as image/i })).toBeInTheDocument();
     });
 
     it('should not render image export option when disabled', async () => {
       config.featureToggles.sharingDashboardImage = false;
+      config.rendererAvailable = true;
+      setup();
+      expect(screen.queryByRole('menuitem', { name: /export as image/i })).not.toBeInTheDocument();
+    });
+
+    it('should not render image export option when the image renderer is not available', async () => {
+      config.featureToggles.sharingDashboardImage = true;
+      config.rendererAvailable = false;
       setup();
       expect(screen.queryByRole('menuitem', { name: /export as image/i })).not.toBeInTheDocument();
     });

--- a/public/app/features/dashboard-scene/sharing/ExportButton/ExportMenu.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/ExportMenu.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { config } from '@grafana/runtime';
 import { SceneTimeRange, VizPanel } from '@grafana/scenes';
@@ -14,9 +15,28 @@ describe('ExportMenu', () => {
     config.rendererAvailable = false;
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('should render menu items', async () => {
     setup();
     expect(await screen.findByRole('menuitem', { name: /export as json/i })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /print/i })).toBeInTheDocument();
+  });
+
+  it('should trigger the browser print dialog after the menu has had a chance to close', async () => {
+    const printSpy = jest.spyOn(window, 'print').mockImplementation(() => {});
+    const requestAnimationFrameSpy = jest.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      callback(0);
+      return 0;
+    });
+
+    setup();
+    await userEvent.click(await screen.findByRole('menuitem', { name: /print/i }));
+
+    expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(1);
+    expect(printSpy).toHaveBeenCalledTimes(1);
   });
 
   describe('sharingDashboardImage feature toggle', () => {

--- a/public/app/features/dashboard-scene/sharing/ExportButton/ExportMenu.tsx
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/ExportMenu.tsx
@@ -55,7 +55,7 @@ export default function ExportMenu({ dashboard }: { dashboard: DashboardScene })
       testId: newExportButtonSelector.exportAsImage,
       icon: 'camera',
       label: t('share-dashboard.menu.export-image-title', 'Export as image'),
-      renderCondition: Boolean(config.featureToggles.sharingDashboardImage),
+      renderCondition: Boolean(config.featureToggles.sharingDashboardImage && config.rendererAvailable),
       onClick: () => onMenuItemClick(shareDashboardType.image),
     });
 

--- a/public/app/features/dashboard-scene/sharing/ExportButton/ExportMenu.tsx
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/ExportMenu.tsx
@@ -60,6 +60,15 @@ export default function ExportMenu({ dashboard }: { dashboard: DashboardScene })
     });
 
     menuItems.push({
+      shareId: 'print',
+      testId: newExportButtonSelector.printDashboard,
+      icon: 'print',
+      label: t('share-dashboard.menu.print-title', 'Print'),
+      renderCondition: true,
+      onClick: () => requestAnimationFrame(() => window.print()),
+    });
+
+    menuItems.push({
       shareId: 'clone',
       testId: newExportButtonSelector.cloneDashboard,
       icon: 'copy',


### PR DESCRIPTION
- **fix: stop showing "export as image" menu if no renderer**
- **feat: add "Print" to the "Export" menu for dashboard**
