### PR TITLE
feat: broadcast dashboard load duration to parent iframe

### DIFF
--- a/public/app/features/dashboard-scene/behaviors/DashboardLoadTimeBroadcast.ts
+++ b/public/app/features/dashboard-scene/behaviors/DashboardLoadTimeBroadcast.ts
@@ -26,10 +26,6 @@ export function dashboardLoadTimeBroadcast(dashboard: DashboardScene) {
 
       if (loadStartTime === null) {
         loadStartTime = performance.now();
-        sendToParent('dashboardLoadStart', {
-          dashboardUid: dashboard.state.uid,
-          dashboardTitle: dashboard.state.title,
-        });
       }
     } else {
       debounceTimer = setTimeout(() => {

--- a/public/app/features/dashboard-scene/behaviors/DashboardLoadTimeBroadcast.ts
+++ b/public/app/features/dashboard-scene/behaviors/DashboardLoadTimeBroadcast.ts
@@ -1,0 +1,70 @@
+import { sceneGraph } from '@grafana/scenes';
+
+import { DashboardScene } from '../scene/DashboardScene';
+
+const DEBOUNCE_MS = 500;
+
+export function dashboardLoadTimeBroadcast(dashboard: DashboardScene) {
+  const queryController = sceneGraph.getQueryController(dashboard);
+  if (!queryController) {
+    return;
+  }
+
+  let loadStartTime: number | null = null;
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const sub = queryController.subscribeToState((newState, prevState) => {
+    if (newState.isRunning === prevState.isRunning) {
+      return;
+    }
+
+    if (newState.isRunning) {
+      if (debounceTimer !== null) {
+        clearTimeout(debounceTimer);
+        debounceTimer = null;
+      }
+
+      if (loadStartTime === null) {
+        loadStartTime = performance.now();
+        sendToParent('dashboardLoadStart', {
+          dashboardUid: dashboard.state.uid,
+          dashboardTitle: dashboard.state.title,
+        });
+      }
+    } else {
+      debounceTimer = setTimeout(() => {
+        if (loadStartTime !== null) {
+          const durationMs = performance.now() - loadStartTime;
+          sendToParent('dashboardLoadComplete', {
+            dashboardUid: dashboard.state.uid,
+            dashboardTitle: dashboard.state.title,
+            durationMs: Math.round(durationMs),
+          });
+          loadStartTime = null;
+        }
+        debounceTimer = null;
+      }, DEBOUNCE_MS);
+    }
+  });
+
+  return () => {
+    sub.unsubscribe();
+    if (debounceTimer !== null) {
+      clearTimeout(debounceTimer);
+    }
+  };
+}
+
+function sendToParent(eventType: string, value: Record<string, unknown>) {
+  window.parent.postMessage(
+    {
+      type: 'message',
+      payload: {
+        source: 'oodle-grafana',
+        eventType,
+        value,
+      },
+    },
+    '*'
+  );
+}

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
@@ -64,6 +64,7 @@ import { DashboardMeta } from 'app/types/dashboard';
 
 import { addPanelsOnLoadBehavior } from '../addToDashboard/addPanelsOnLoadBehavior';
 import { dashboardAnalyticsInitializer } from '../behaviors/DashboardAnalyticsInitializerBehavior';
+import { dashboardLoadTimeBroadcast } from '../behaviors/DashboardLoadTimeBroadcast';
 import { DashboardAnnotationsDataLayer } from '../scene/DashboardAnnotationsDataLayer';
 import { DashboardControls } from '../scene/DashboardControls';
 import { DashboardDataLayerSet } from '../scene/DashboardDataLayerSet';
@@ -228,6 +229,7 @@ export function transformSaveModelSchemaV2ToScene(dto: DashboardWithAccessInfo<D
           uid: dashboardId?.toString(),
         }),
         ...(enableProfiling ? [dashboardAnalyticsInitializer] : []),
+        dashboardLoadTimeBroadcast,
       ],
       $data: new DashboardDataLayerSet({
         annotationLayers,

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
@@ -33,6 +33,7 @@ import { DashboardDTO, DashboardDataDTO } from 'app/types/dashboard';
 
 import { addPanelsOnLoadBehavior } from '../addToDashboard/addPanelsOnLoadBehavior';
 import { dashboardAnalyticsInitializer } from '../behaviors/DashboardAnalyticsInitializerBehavior';
+import { dashboardLoadTimeBroadcast } from '../behaviors/DashboardLoadTimeBroadcast';
 import { AlertStatesDataLayer } from '../scene/AlertStatesDataLayer';
 import { DashboardAnnotationsDataLayer } from '../scene/DashboardAnnotationsDataLayer';
 import { DashboardControls } from '../scene/DashboardControls';
@@ -339,6 +340,9 @@ export function createDashboardSceneFromDashboardModel(oldModel: DashboardModel,
     // Analytics aggregator lifecycle management (initialization, observer registration, cleanup)
     behaviorList.push(dashboardAnalyticsInitializer);
   }
+
+  behaviorList.push(dashboardLoadTimeBroadcast);
+
   // Will be enabled in the dashboard creation below
 
   let body: DashboardLayoutManager;


### PR DESCRIPTION
## Summary
- Adds a `dashboardLoadTimeBroadcast` scene behavior that subscribes to `SceneQueryController.isRunning` state transitions
- Sends `dashboardLoadStart` and `dashboardLoadComplete` postMessage events to the parent iframe with dashboard UID, title, and load duration in ms
- Includes 500ms debounce so scroll-triggered lazy panel loads get merged into a single measurement instead of producing rapid start/complete flickers
- Wired into both V1 (`transformSaveModelToScene`) and V2 (`transformSaveModelSchemaV2ToScene`) serialization paths