### PR TITLE
Fix interval calculation with query splitting

### DIFF
--- a/packages/grafana-data/src/dataframe/processDataFrame.test.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.test.ts
@@ -1,6 +1,9 @@
 import { dateTime } from '../datetime/moment_wrapper';
-import { TimeSeries, TableData } from '../types/data';
+import { TimeSeries, TableData, LoadingState } from '../types/data';
 import { FieldType, DataFrameDTO, Field } from '../types/dataFrame';
+import { QueryStreamProgress } from '../types/datasource';
+import { PanelData } from '../types/panel';
+import { getDefaultTimeRange } from '../types/time';
 
 import { ArrayDataFrame } from './ArrayDataFrame';
 import {
@@ -11,6 +14,7 @@ import {
   guessFieldTypes,
   isDataFrame,
   isTableData,
+  preProcessPanelData,
   reverseDataFrame,
   sortDataFrame,
   toDataFrame,
@@ -514,5 +518,46 @@ describe('guessFieldTypeForField', () => {
     field.values = [];
 
     expect(guessFieldTypeForField(field)).toBe(undefined);
+  });
+});
+
+describe('preProcessPanelData', () => {
+  const progress = (requestId: string): QueryStreamProgress => ({
+    requestId,
+    fromMs: 0,
+    toMs: 100,
+    loadedFromMs: 50,
+    loadedToMs: 100,
+    completedParts: 1,
+    totalParts: 2,
+    streaming: true,
+  });
+
+  const panelData = (overrides: Partial<PanelData>): PanelData => ({
+    state: LoadingState.Loading,
+    series: [],
+    timeRange: getDefaultTimeRange(),
+    ...overrides,
+  });
+
+  it('keeps rendering the last result while a request without data so far is loading', () => {
+    const last = panelData({ state: LoadingState.Done, series: [toDataFrame({ fields: [] })] });
+    const result = preProcessPanelData(panelData({}), last);
+
+    expect(result.series).toBe(last.series);
+    expect(result.state).toBe(LoadingState.Loading);
+  });
+
+  it('reports the progress of the request being loaded, not the one of the last result', () => {
+    // A split query whose newest parts came back empty: the panel still shows the previous result,
+    // but the unloaded region has to be the one of the request that is running
+    const last = panelData({ state: LoadingState.Done, series: [toDataFrame({ fields: [] })] });
+    last.streamProgress = progress('previous');
+
+    const loading = panelData({});
+    loading.streamProgress = progress('current');
+
+    expect(preProcessPanelData(loading, last).streamProgress).toEqual(progress('current'));
+    expect(preProcessPanelData(panelData({}), last).streamProgress).toBeUndefined();
   });
 });

--- a/packages/grafana-data/src/dataframe/processDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.ts
@@ -568,6 +568,9 @@ export function preProcessPanelData(data: PanelData, lastResult?: PanelData): Pa
       ...lastResult,
       state: LoadingState.Loading,
       request: data.request,
+      // Belongs to the request being loaded, the one of the last result describes a range that is
+      // not being loaded anymore
+      streamProgress: data.streamProgress,
     };
   }
 

--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -686,6 +686,7 @@ export {
   type TestDataSourceResponse,
   type DataQueryError,
   type DataQueryRequest,
+  type QuerySplitOrigin,
   type DataQueryTimings,
   type QueryFix,
   type QueryFixType,

--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -634,6 +634,28 @@ export interface DataQueryRequest<TQuery extends DataQuery = DataQuery> {
   queryGroupId?: string;
 
   scopes?: Scope[] | undefined;
+
+  /**
+   * Set when this request only covers a part of the range the user asked for, because the
+   * query was split into several sub requests that resolve progressively.
+   */
+  splitOrigin?: QuerySplitOrigin;
+}
+
+/**
+ * Describes the unsplit request a sub request was derived from. Everything that is a function of
+ * the query range - the step, `$__interval`, `$__rate_interval`, `$__dd_interval`,
+ * `$__large_interval`, `$__range` - has to be calculated from these values instead of from the
+ * range of the part, otherwise every part is sampled differently and the merged result does not
+ * match what an unsplit query would have returned.
+ */
+export interface QuerySplitOrigin {
+  /** Start of the full requested time range (epoch ms) */
+  fromMs: number;
+  /** End of the full requested time range (epoch ms) */
+  toMs: number;
+  /** maxDataPoints of the unsplit request, the parts get a scaled down value */
+  maxDataPoints?: number;
 }
 
 export interface DataQueryTimings {

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -148,6 +148,40 @@ describe('DataSourceWithBackend', () => {
     `);
   });
 
+  test('sends the range of the unsplit request with every part of a split request', () => {
+    const { mock, ds } = createMockDatasource();
+    const range = getDefaultTimeRange();
+    ds.query({
+      maxDataPoints: 10,
+      intervalMs: 5000,
+      targets: [{ refId: 'A' }],
+      range,
+      splitOrigin: {
+        fromMs: range.from.valueOf() - 10000,
+        toMs: range.to.valueOf(),
+        maxDataPoints: 100,
+      },
+    } as DataQueryRequest);
+
+    const query = mock.calls[0][0].data.queries[0];
+    expect(query.fullTimeRangeMs).toBe(range.to.valueOf() - range.from.valueOf() + 10000);
+    expect(query.fullMaxDataPoints).toBe(100);
+  });
+
+  test('does not send split properties for a regular request', () => {
+    const { mock, ds } = createMockDatasource();
+    ds.query({
+      maxDataPoints: 10,
+      intervalMs: 5000,
+      targets: [{ refId: 'A' }],
+      range: getDefaultTimeRange(),
+    } as DataQueryRequest);
+
+    const query = mock.calls[0][0].data.queries[0];
+    expect(query).not.toHaveProperty('fullTimeRangeMs');
+    expect(query).not.toHaveProperty('fullMaxDataPoints');
+  });
+
   test('correctly passes datasource headers', () => {
     const { mock, ds } = createMockDatasource();
     ds.query({

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -139,7 +139,26 @@ class DataSourceWithBackend<
       return publicDashboardQueryHandler(request);
     }
 
-    const { intervalMs, maxDataPoints, queryCachingTTL, range, requestId, hideFromInspector = false } = request;
+    const {
+      intervalMs,
+      maxDataPoints,
+      queryCachingTTL,
+      range,
+      requestId,
+      hideFromInspector = false,
+      splitOrigin,
+    } = request;
+
+    // A request that covers only a part of the range the user asked for still has to calculate
+    // its step and its interval variables from the full range, otherwise the parts of a split
+    // query end up sampled at different resolutions
+    const splitProps = splitOrigin
+      ? {
+          fullTimeRangeMs: splitOrigin.toMs - splitOrigin.fromMs,
+          fullMaxDataPoints: splitOrigin.maxDataPoints,
+        }
+      : undefined;
+
     let targets = request.targets;
 
     let hasExpr = false;
@@ -189,6 +208,7 @@ class DataSourceWithBackend<
         intervalMs,
         maxDataPoints,
         queryCachingTTL,
+        ...splitProps,
       };
     });
 

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -359,9 +359,10 @@ export function PanelChrome({
         ref={ref}
       >
         <div className={styles.loadingBarContainer}>
-          {/* Streaming keeps the bar running while partial results are already rendered, e.g. a
-              query split into several time ranges that fills the panel in as the parts arrive */}
-          {loadingState === LoadingState.Loading || loadingState === LoadingState.Streaming ? (
+          {/* A split query reports Loading between parts, so the bar keeps running while the
+              partial results are already rendered. Live streaming panels stay on Streaming for as
+              long as they are open and must not show a bar that never ends. */}
+          {loadingState === LoadingState.Loading ? (
             <LoadingBar
               width={loadingBarWidth}
               ariaLabel={t('grafana-ui.panel-chrome.ariaLabel-panel-loading', 'Panel loading bar')}

--- a/pkg/promlib/models/query.go
+++ b/pkg/promlib/models/query.go
@@ -170,6 +170,41 @@ type internalQueryModel struct {
 	// Do not use this parameter.
 	UtcOffsetSec int64  `json:"utcOffsetSecDoNotUse,omitempty"`
 	Interval     string `json:"interval,omitempty"`
+
+	// Set when the query is one part of a request that the frontend split into several sub
+	// requests over consecutive parts of the requested range. They describe the range and the
+	// max data points of the unsplit request, everything that is derived from the range - the
+	// step, $__interval, $__rate_interval, $__dd_interval, $__large_interval, $__range - has to
+	// be calculated from those instead of from the range of the part. Otherwise every part is
+	// sampled at a different resolution and the merged result does not match the unsplit query.
+	FullTimeRangeMs   int64 `json:"fullTimeRangeMs,omitempty"`
+	FullMaxDataPoints int64 `json:"fullMaxDataPoints,omitempty"`
+}
+
+// intervalTimeRange returns the time range every range dependent value should be calculated from.
+// It is the query range, unless the query is a part of a split request, in which case it is the
+// range of the unsplit request. Only its duration is used, so it is anchored at the query end.
+func (m *internalQueryModel) intervalTimeRange(query backend.DataQuery) backend.TimeRange {
+	if m.FullTimeRangeMs <= 0 {
+		return query.TimeRange
+	}
+
+	fullRange := time.Duration(m.FullTimeRangeMs) * time.Millisecond
+
+	return backend.TimeRange{
+		From: query.TimeRange.To.Add(-fullRange),
+		To:   query.TimeRange.To,
+	}
+}
+
+// intervalMaxDataPoints returns the max data points the step should be calculated with. Parts of a
+// split request carry a scaled down value, the step has to stay the one of the unsplit request.
+func (m *internalQueryModel) intervalMaxDataPoints(query backend.DataQuery) int64 {
+	if m.FullTimeRangeMs <= 0 || m.FullMaxDataPoints <= 0 {
+		return query.MaxDataPoints
+	}
+
+	return m.FullMaxDataPoints
 }
 
 func Parse(ctx context.Context, log glog.Logger, span trace.Span, query backend.DataQuery, dsScrapeInterval string, intervalCalculator intervalv2.Calculator, fromAlert bool) (*Query, error) {
@@ -179,11 +214,13 @@ func Parse(ctx context.Context, log glog.Logger, span trace.Span, query backend.
 	}
 	span.SetAttributes(attribute.String("rawExpr", model.Expr))
 
-	// Interpolate variables in expr
-	timeRange := query.TimeRange.To.Sub(query.TimeRange.From)
+	// Interpolate variables in expr. Range dependent values are calculated from the range of the
+	// unsplit request when this query is one part of a split request.
+	intervalTimeRange := model.intervalTimeRange(query)
+	timeRange := intervalTimeRange.To.Sub(intervalTimeRange.From)
 
 	// Final step value for prometheus
-	calculatedStep, err := calculatePrometheusInterval(&model.Interval, dsScrapeInterval, int64(model.IntervalMS), model.IntervalFactor, query, intervalCalculator, timeRange)
+	calculatedStep, err := calculatePrometheusInterval(&model.Interval, dsScrapeInterval, int64(model.IntervalMS), model.IntervalFactor, intervalTimeRange, model.intervalMaxDataPoints(query), intervalCalculator)
 	if err != nil {
 		return nil, err
 	}
@@ -283,14 +320,18 @@ func (query *Query) TimeRange() TimeRange {
 	}
 }
 
+// calculatePrometheusInterval calculates the final step of the query. timeRange and maxDataPoints
+// describe the range the user asked for, which is not the range of the query itself when the
+// request was split into several parts.
 func calculatePrometheusInterval(
 	queryIntervalIn *string,
 	dsScrapeInterval string,
 	intervalMs, intervalFactor int64,
-	query backend.DataQuery,
+	timeRange backend.TimeRange,
+	maxDataPoints int64,
 	intervalCalculator intervalv2.Calculator,
-	timeRange time.Duration,
 ) (time.Duration, error) {
+	rangeDuration := timeRange.To.Sub(timeRange.From)
 	queryInterval := *queryIntervalIn
 	// we need to compare the original query model after it is overwritten below to variables so that we can
 	// calculate the rateInterval if it is equal to $__rate_interval or ${__rate_interval}
@@ -305,8 +346,8 @@ func calculatePrometheusInterval(
 	if err != nil {
 		return time.Duration(0), err
 	}
-	calculatedInterval := intervalCalculator.Calculate(query.TimeRange, minInterval, query.MaxDataPoints)
-	safeInterval := intervalCalculator.CalculateSafeInterval(query.TimeRange, int64(safeResolution))
+	calculatedInterval := intervalCalculator.Calculate(timeRange, minInterval, maxDataPoints)
+	safeInterval := intervalCalculator.CalculateSafeInterval(timeRange, int64(safeResolution))
 
 	adjustedInterval := safeInterval.Value
 	if calculatedInterval.Value > safeInterval.Value {
@@ -319,12 +360,12 @@ func calculatePrometheusInterval(
 		resInterval := calculateRateInterval(adjustedInterval, dsScrapeInterval)
 		return resInterval, nil
 	} else if originalQueryInterval == varDDInterval {
-		resInterval := CalculateIntervalDatadogDefault(timeRange)
+		resInterval := CalculateIntervalDatadogDefault(rangeDuration)
 		// The below fix is only applied to DD interval to avoid changing behavior of default grafana.
 		*queryIntervalIn = resInterval.String()
 		return resInterval, nil
 	} else if originalQueryInterval == varLargeInterval {
-		resInterval := CalculateIntervalDatadogBarChart(timeRange)
+		resInterval := CalculateIntervalDatadogBarChart(rangeDuration)
 		return resInterval, nil
 	} else {
 		queryIntervalFactor := intervalFactor

--- a/pkg/promlib/models/query_test.go
+++ b/pkg/promlib/models/query_test.go
@@ -973,6 +973,92 @@ func mockQuery(expr string, interval string, intervalMs int64, timeRange *backen
 	}
 }
 
+// A request the frontend split into several parts must be parsed exactly like the unsplit request:
+// the step and every interval variable are a function of the range the user asked for, not of the
+// range of the part.
+func TestParseSplitRequest(t *testing.T) {
+	_, span := tracer.Start(context.Background(), "operation")
+	defer span.End()
+
+	fullRange := 7 * 24 * time.Hour
+	maxDataPoints := int64(1000)
+	// The parts a 7 day range is split into, newest first
+	parts := 10
+	partRange := fullRange / time.Duration(parts)
+
+	queryJSON := func(expr string, minStep string, split bool) string {
+		splitProps := ""
+		if split {
+			splitProps = fmt.Sprintf(`"fullTimeRangeMs": %d, "fullMaxDataPoints": %d,`, fullRange.Milliseconds(), maxDataPoints)
+		}
+		return fmt.Sprintf(`{
+			"expr": %q,
+			"format": "time_series",
+			"interval": %q,
+			"refId": "A",
+			%s
+			"intervalFactor": 1
+		}`, expr, minStep, splitProps)
+	}
+
+	for _, tc := range []struct {
+		name    string
+		expr    string
+		minStep string
+	}{
+		{name: "$__dd_interval", expr: "sum(rate(go_goroutines[$__dd_interval]))"},
+		{name: "$__large_interval", expr: "sum(rate(go_goroutines[$__large_interval]))"},
+		{name: "$__rate_interval", expr: "sum(rate(go_goroutines[$__rate_interval]))"},
+		{name: "$__interval", expr: "sum(rate(go_goroutines[$__interval]))"},
+		{name: "$__range", expr: "sum(rate(go_goroutines[$__range])) + $__range_s + $__range_ms"},
+		{name: "$__dd_interval as min step", expr: "sum(rate(go_goroutines[$__rate_interval]))", minStep: "$__dd_interval"},
+		{name: "$__large_interval as min step", expr: "sum(rate(go_goroutines[$__interval]))", minStep: "$__large_interval"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			unsplit := backend.DataQuery{
+				RefID:         "A",
+				JSON:          []byte(queryJSON(tc.expr, tc.minStep, false)),
+				MaxDataPoints: maxDataPoints,
+				TimeRange:     backend.TimeRange{From: now.Add(-fullRange), To: now},
+			}
+
+			expected, err := models.Parse(context.Background(), log.New(), span, unsplit, "15s", intervalCalculator, false)
+			require.NoError(t, err)
+
+			for part := 0; part < parts; part++ {
+				to := now.Add(-time.Duration(part) * partRange)
+				split := backend.DataQuery{
+					RefID: "A",
+					JSON:  []byte(queryJSON(tc.expr, tc.minStep, true)),
+					// Parts carry a maxDataPoints scaled down to their share of the range
+					MaxDataPoints: maxDataPoints / int64(parts),
+					TimeRange:     backend.TimeRange{From: to.Add(-partRange), To: to},
+				}
+
+				res, err := models.Parse(context.Background(), log.New(), span, split, "15s", intervalCalculator, false)
+				require.NoError(t, err)
+				require.Equal(t, expected.Expr, res.Expr, "part %d interpolated the query differently", part)
+				require.Equal(t, expected.Step, res.Step, "part %d uses a different step", part)
+			}
+		})
+	}
+
+	t.Run("query range is still the range of the part", func(t *testing.T) {
+		to := now.Add(-partRange)
+		split := backend.DataQuery{
+			RefID:         "A",
+			JSON:          []byte(queryJSON("go_goroutines", "", true)),
+			MaxDataPoints: maxDataPoints / int64(parts),
+			TimeRange:     backend.TimeRange{From: to.Add(-partRange), To: to},
+		}
+
+		res, err := models.Parse(context.Background(), log.New(), span, split, "15s", intervalCalculator, false)
+		require.NoError(t, err)
+		require.Equal(t, to.Add(-partRange), res.Start)
+		require.Equal(t, to, res.End)
+	})
+}
+
 func queryContext(json string, timeRange backend.TimeRange, queryInterval time.Duration) backend.DataQuery {
 	return backend.DataQuery{
 		Interval:  queryInterval,

--- a/public/app/features/query/state/streaming/splitQuery.test.ts
+++ b/public/app/features/query/state/streaming/splitQuery.test.ts
@@ -11,6 +11,7 @@ import {
   dateTime,
   toDataFrame,
 } from '@grafana/data';
+import { config as runtimeConfig } from '@grafana/runtime';
 
 import { DEFAULT_STREAMING_CONFIG, QueryStreamingConfig } from './config';
 import { QueryExecutor, getRequestSplitParts, runSplitRequest } from './splitQuery';
@@ -88,6 +89,15 @@ describe('getRequestSplitParts', () => {
       expect(getRequestSplitParts(datasource, request, config)).toBe(1);
     }
   );
+
+  it('does not split on a public dashboard', () => {
+    runtimeConfig.publicDashboardAccessToken = 'token';
+    try {
+      expect(getRequestSplitParts(datasource, makeRequest(), config)).toBe(1);
+    } finally {
+      runtimeConfig.publicDashboardAccessToken = undefined;
+    }
+  });
 
   it('does not split when incremental querying is on', () => {
     const ds = { type: 'prometheus', hasIncrementalQuery: true } as unknown as DataSourceApi;

--- a/public/app/features/query/state/streaming/splitQuery.test.ts
+++ b/public/app/features/query/state/streaming/splitQuery.test.ts
@@ -81,10 +81,13 @@ describe('getRequestSplitParts', () => {
     expect(getRequestSplitParts(datasource, request, config)).toBe(1);
   });
 
-  it('does not split queries that use $__range', () => {
-    const request = makeRequest({ targets: [target({ refId: 'A', expr: 'sum_over_time(up[$__range])' })] });
-    expect(getRequestSplitParts(datasource, request, config)).toBe(1);
-  });
+  it.each(['sum_over_time(up[$__range])', 'sum_over_time(up[${__range}])', 'up + ${__range_s}'])(
+    'does not split queries that use the range variable in %s',
+    (expr) => {
+      const request = makeRequest({ targets: [target({ refId: 'A', expr })] });
+      expect(getRequestSplitParts(datasource, request, config)).toBe(1);
+    }
+  );
 
   it('does not split when incremental querying is on', () => {
     const ds = { type: 'prometheus', hasIncrementalQuery: true } as unknown as DataSourceApi;
@@ -157,6 +160,27 @@ describe('runSplitRequest', () => {
       // The step of the panel is untouched
       expect(req.intervalMs).toBe(request.intervalMs);
       expect(req.range.raw).toEqual(request.range.raw);
+    });
+  });
+
+  it('passes the range of the unsplit request to every part', async () => {
+    const request = makeRequest({ maxDataPoints: 1000 });
+    const requests: DataQueryRequest[] = [];
+
+    const executor: QueryExecutor = (_ds, req) => {
+      requests.push(req);
+      return of<DataQueryResponse>({ data: [] });
+    };
+
+    await collect(runSplitRequest(datasource, request, undefined, 4, executor));
+
+    expect(requests.length).toBe(4);
+    requests.forEach((req) => {
+      expect(req.splitOrigin).toEqual({
+        fromMs: request.range.from.valueOf(),
+        toMs: request.range.to.valueOf(),
+        maxDataPoints: 1000,
+      });
     });
   });
 

--- a/public/app/features/query/state/streaming/splitQuery.ts
+++ b/public/app/features/query/state/streaming/splitQuery.ts
@@ -75,8 +75,10 @@ export function getRequestSplitParts(
       return 1;
     }
 
-    // $__range, $__range_s and $__range_ms would be interpolated per part and change the query
-    if ('expr' in target && typeof target.expr === 'string' && target.expr.includes('$__range')) {
+    // $__range is interpolated from the full range (see splitOrigin), so the parts do return the
+    // right numbers, but a `[$__range]` window is evaluated once per part and each evaluation
+    // still reads the whole range, which multiplies the work done by the datasource
+    if ('expr' in target && typeof target.expr === 'string' && hasRangeVariable(target.expr)) {
       return 1;
     }
   }
@@ -85,6 +87,11 @@ export function getRequestSplitParts(
   const toMs = request.range.to.valueOf();
 
   return calculateStreamingParts(toMs - fromMs, config.thresholds);
+}
+
+/** Matches both `$__range`, `$__range_s`, `$__range_ms` and their `${...}` spelling */
+function hasRangeVariable(expr: string): boolean {
+  return expr.includes('$__range') || expr.includes('${__range');
 }
 
 export function scaleMaxDataPoints(
@@ -186,6 +193,13 @@ export function runSplitRequest(
         // Datasources derive the step from range/maxDataPoints, keep the ratio of the full
         // request so every part is sampled at the same resolution
         maxDataPoints: scaleMaxDataPoints(request.maxDataPoints, range.toMs - range.fromMs, toMs - fromMs),
+        // The step and the interval variables ($__interval, $__rate_interval, $__dd_interval,
+        // $__large_interval, $__range) must not be derived from the range of the part
+        splitOrigin: {
+          fromMs,
+          toMs,
+          maxDataPoints: request.maxDataPoints,
+        },
         range: {
           from: dateTime(range.fromMs),
           to: dateTime(range.toMs),

--- a/public/app/features/query/state/streaming/splitQuery.ts
+++ b/public/app/features/query/state/streaming/splitQuery.ts
@@ -10,7 +10,7 @@ import {
   QueryStreamProgress,
   dateTime,
 } from '@grafana/data';
-import { isExpressionReference, toDataQueryError } from '@grafana/runtime';
+import { config as runtimeConfig, isExpressionReference, toDataQueryError } from '@grafana/runtime';
 import { backendSrv } from 'app/core/services/backend_srv';
 
 import { QueryStreamingConfig, getQueryStreamingConfig } from './config';
@@ -51,6 +51,13 @@ export function getRequestSplitParts(
   }
 
   if (request.liveStreaming) {
+    return 1;
+  }
+
+  // Public dashboards go through their own endpoint, which rebuilds the queries from the saved
+  // dashboard and only receives the range and maxDataPoints of the request. There is no way to
+  // tell it the range of the unsplit request, so every part would pick its own step
+  if (runtimeConfig.publicDashboardAccessToken) {
     return 1;
   }
 

--- a/public/app/plugins/panel/timeseries/plugins/StreamingProgressPlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/StreamingProgressPlugin.tsx
@@ -1,4 +1,4 @@
-import { css, keyframes } from '@emotion/css';
+import { css } from '@emotion/css';
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import uPlot from 'uplot';
@@ -184,12 +184,6 @@ export function getUnloadedRegion(
   return null;
 }
 
-// Same shape as the react-loading-skeleton sweep: a highlight crossing the block and starting over
-const shimmer = keyframes({
-  '0%': { transform: 'translateX(-100%)' },
-  '60%, 100%': { transform: 'translateX(350%)' },
-});
-
 const getStyles = (theme: GrafanaTheme2) => {
   const base = {
     position: 'absolute' as const,
@@ -201,7 +195,6 @@ const getStyles = (theme: GrafanaTheme2) => {
   // The skeleton palette configured for react-loading-skeleton in ConfigProvider, kept translucent
   // so the grid lines of the empty region still show through
   const baseColor = colorManipulator.alpha(theme.colors.emphasize(theme.colors.background.secondary), 0.75);
-  const highlightColor = theme.colors.emphasize(theme.colors.background.secondary, 0.1);
 
   return {
     loading: css({


### PR DESCRIPTION
Interval calculation like $__large_interval should use the whole range
not the split range