### PR TITLE
Split long queries into fixed 30 day parts

### DIFF
--- a/public/app/features/query/state/streaming/config.test.ts
+++ b/public/app/features/query/state/streaming/config.test.ts
@@ -2,6 +2,7 @@ import { store } from '@grafana/data';
 import { config } from '@grafana/runtime';
 
 import {
+  DEFAULT_SPLIT_INTERVAL_MINUTES,
   DEFAULT_STREAMING_CONFIG,
   STREAMING_CONFIG_STORAGE_KEY,
   clearQueryStreamingConfigCache,
@@ -23,11 +24,11 @@ describe('getQueryStreamingConfig', () => {
   });
 
   it('overrides only the keys that are stored', () => {
-    setQueryStreamingConfig({ thresholds: [{ durationMinutes: 60, parts: 4 }] });
+    setQueryStreamingConfig({ splitIntervalMinutes: 60 });
 
     const config = getQueryStreamingConfig();
 
-    expect(config.thresholds).toEqual([{ durationMinutes: 60, parts: 4 }]);
+    expect(config.splitIntervalMinutes).toBe(60);
     expect(config.panelTypes).toEqual(DEFAULT_STREAMING_CONFIG.panelTypes);
     expect(config.enabled).toBe(true);
   });
@@ -45,30 +46,24 @@ describe('getQueryStreamingConfig', () => {
   });
 
   it('toggles the flag without losing the other stored settings', () => {
-    setQueryStreamingConfig({ thresholds: [{ durationMinutes: 60, parts: 4 }] });
+    setQueryStreamingConfig({ splitIntervalMinutes: 60 });
 
     setQuerySplittingEnabled(false);
     expect(isQuerySplittingEnabled()).toBe(false);
-    expect(getQueryStreamingConfig().thresholds).toEqual([{ durationMinutes: 60, parts: 4 }]);
+    expect(getQueryStreamingConfig().splitIntervalMinutes).toBe(60);
 
     setQuerySplittingEnabled(true);
     expect(isQuerySplittingEnabled()).toBe(true);
-    expect(getQueryStreamingConfig().thresholds).toEqual([{ durationMinutes: 60, parts: 4 }]);
+    expect(getQueryStreamingConfig().splitIntervalMinutes).toBe(60);
   });
 
-  it('splits ranges from 6 hours up by default', () => {
-    expect(getQueryStreamingConfig().thresholds).toEqual([
-      { durationMinutes: 10080, parts: 10 },
-      { durationMinutes: 4320, parts: 8 },
-      { durationMinutes: 2880, parts: 6 },
-      { durationMinutes: 1440, parts: 4 },
-      { durationMinutes: 720, parts: 3 },
-      { durationMinutes: 360, parts: 2 },
-    ]);
+  it('splits ranges longer than 30 days by default', () => {
+    expect(getQueryStreamingConfig().splitIntervalMinutes).toBe(DEFAULT_SPLIT_INTERVAL_MINUTES);
+    expect(DEFAULT_SPLIT_INTERVAL_MINUTES).toBe(30 * 24 * 60);
   });
 
   it('ignores malformed values', () => {
-    store.set(STREAMING_CONFIG_STORAGE_KEY, '{"thresholds": "nope", "panelTypes": [1]}');
+    store.set(STREAMING_CONFIG_STORAGE_KEY, '{"splitIntervalMinutes": "nope", "panelTypes": [1]}');
     clearQueryStreamingConfigCache();
 
     expect(getQueryStreamingConfig()).toEqual(DEFAULT_STREAMING_CONFIG);

--- a/public/app/features/query/state/streaming/config.ts
+++ b/public/app/features/query/state/streaming/config.ts
@@ -1,22 +1,14 @@
 import { CoreApp, store } from '@grafana/data';
 import { config } from '@grafana/runtime';
 
-/**
- * How many parts a query should be split into for a given time range duration.
- */
-export interface StreamingThreshold {
-  durationMinutes: number;
-  parts: number;
-}
-
 export interface QueryStreamingConfig {
   /** Turns query splitting on/off */
   enabled: boolean;
   /**
-   * Thresholds define how many parts to split queries into based on time range duration
-   * (in minutes). Queries shorter than the smallest threshold use a single request.
+   * Longest range (in minutes) a single request may cover. Queries over this duration are split
+   * into as many parts as needed, shorter ones run as a single request.
    */
-  thresholds: StreamingThreshold[];
+  splitIntervalMinutes: number;
   /** Panel plugin ids that render progressive results correctly */
   panelTypes: string[];
   /** Datasource types that support splitting a range query by time */
@@ -25,23 +17,12 @@ export interface QueryStreamingConfig {
   apps: string[];
 }
 
-/**
- * Default: 7+ days (10080 min) -> 10 parts, 3+ days (4320 min) -> 8 parts, 2+ days (2880 min) -> 6 parts,
- * 1+ day (1440 min) -> 4 parts, 12+ hours (720 min) -> 3 parts, 6+ hours (360 min) -> 2 parts.
- * Anything shorter than 6 hours runs as a single request.
- */
-export const DEFAULT_STREAMING_THRESHOLDS: StreamingThreshold[] = [
-  { durationMinutes: 10080, parts: 10 },
-  { durationMinutes: 4320, parts: 8 },
-  { durationMinutes: 2880, parts: 6 },
-  { durationMinutes: 1440, parts: 4 },
-  { durationMinutes: 720, parts: 3 },
-  { durationMinutes: 360, parts: 2 },
-];
+/** 30 days: ranges up to this run as a single request, longer ones are split into 30 day parts */
+export const DEFAULT_SPLIT_INTERVAL_MINUTES = 30 * 24 * 60;
 
 export const DEFAULT_STREAMING_CONFIG: QueryStreamingConfig = {
   enabled: true,
-  thresholds: DEFAULT_STREAMING_THRESHOLDS,
+  splitIntervalMinutes: DEFAULT_SPLIT_INTERVAL_MINUTES,
   panelTypes: ['timeseries'],
   datasourceTypes: ['prometheus'],
   apps: [CoreApp.Dashboard, CoreApp.PanelEditor, CoreApp.PanelViewer],
@@ -49,7 +30,7 @@ export const DEFAULT_STREAMING_CONFIG: QueryStreamingConfig = {
 
 /**
  * Local storage key holding a JSON override of {@link DEFAULT_STREAMING_CONFIG}, e.g.
- * `{"thresholds":[{"durationMinutes":10080,"parts":10}]}`. Only the provided keys are overridden.
+ * `{"splitIntervalMinutes":10080}`. Only the provided keys are overridden.
  */
 export const STREAMING_CONFIG_STORAGE_KEY = 'grafana.query.streamingConfig';
 
@@ -111,8 +92,8 @@ function readOverrides(): Partial<QueryStreamingConfig> {
     if (typeof parsed.enabled === 'boolean') {
       overrides.enabled = parsed.enabled;
     }
-    if (isThresholdArray(parsed.thresholds)) {
-      overrides.thresholds = parsed.thresholds;
+    if (typeof parsed.splitIntervalMinutes === 'number' && parsed.splitIntervalMinutes > 0) {
+      overrides.splitIntervalMinutes = parsed.splitIntervalMinutes;
     }
     if (isStringArray(parsed.panelTypes)) {
       overrides.panelTypes = parsed.panelTypes;
@@ -132,11 +113,4 @@ function readOverrides(): Partial<QueryStreamingConfig> {
 
 function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((v) => typeof v === 'string');
-}
-
-function isThresholdArray(value: unknown): value is StreamingThreshold[] {
-  return (
-    Array.isArray(value) &&
-    value.every((v) => v && typeof v.durationMinutes === 'number' && typeof v.parts === 'number' && v.parts > 0)
-  );
 }

--- a/public/app/features/query/state/streaming/runRequestSplitting.test.ts
+++ b/public/app/features/query/state/streaming/runRequestSplitting.test.ts
@@ -24,7 +24,7 @@ jest.mock('app/features/dashboard/services/DashboardSrv', () => ({
 
 const STEP_MS = 60 * 60 * 1000;
 const TO_MS = 1700000000000;
-const FROM_MS = TO_MS - 8 * 24 * 60 * 60 * 1000;
+const FROM_MS = TO_MS - 120 * 24 * 60 * 60 * 1000;
 
 function makeRequest(): DataQueryRequest {
   return {
@@ -32,7 +32,7 @@ function makeRequest(): DataQueryRequest {
     interval: '1h',
     intervalMs: STEP_MS,
     maxDataPoints: 200,
-    range: { from: dateTime(FROM_MS), to: dateTime(TO_MS), raw: { from: 'now-8d', to: 'now' } },
+    range: { from: dateTime(FROM_MS), to: dateTime(TO_MS), raw: { from: 'now-120d', to: 'now' } },
     scopedVars: {},
     targets: [{ refId: 'A' }],
     timezone: 'browser',
@@ -97,7 +97,7 @@ describe('runRequest with query splitting', () => {
     const unsplit = await collect({ ...makeRequest(), panelPluginId: 'table' }, datasource);
 
     const dataEmissions = split.filter((data) => data.series.length > 0);
-    expect(dataEmissions.length).toBe(10);
+    expect(dataEmissions.length).toBe(4);
 
     // Every emission covers more of the range than the previous one, growing to the left
     const times = dataEmissions.map((data) => data.series[0].fields[0].values);
@@ -127,10 +127,10 @@ describe('runRequest with query splitting', () => {
     expect(first.fromMs).toBe(FROM_MS);
     expect(first.toMs).toBe(TO_MS);
     expect(first.loadedFromMs).toBeGreaterThan(FROM_MS);
-    expect(first.totalParts).toBe(10);
+    expect(first.totalParts).toBe(4);
     expect(results[0].state).toBe(LoadingState.Loading);
 
-    // The range is relative ('now-8d' to 'now'), it must not be re-resolved between parts or the
+    // The range is relative ('now-120d' to 'now'), it must not be re-resolved between parts or the
     // axis would creep while the panel fills in
     results.forEach((result) => {
       expect(result.timeRange.from.valueOf()).toBe(FROM_MS);

--- a/public/app/features/query/state/streaming/splitQuery.test.ts
+++ b/public/app/features/query/state/streaming/splitQuery.test.ts
@@ -24,13 +24,13 @@ const target = (t: { refId: string; expr?: string; instant?: boolean; hide?: boo
 
 function makeRequest(overrides: Partial<DataQueryRequest> = {}): DataQueryRequest {
   const to = dateTime(1700000000000);
-  const from = dateTime(to.valueOf() - 8 * 24 * 60 * 60 * 1000);
+  const from = dateTime(to.valueOf() - 90 * 24 * 60 * 60 * 1000);
 
   return {
     requestId: 'req1',
     interval: '1m',
     intervalMs: 60000,
-    range: { from, to, raw: { from: 'now-8d', to: 'now' } },
+    range: { from, to, raw: { from: 'now-90d', to: 'now' } },
     scopedVars: {},
     targets: [target({ refId: 'A', expr: 'up' })],
     timezone: 'browser',
@@ -43,7 +43,7 @@ function makeRequest(overrides: Partial<DataQueryRequest> = {}): DataQueryReques
 
 describe('getRequestSplitParts', () => {
   it('splits a long range on a supported panel and datasource', () => {
-    expect(getRequestSplitParts(datasource, makeRequest(), config)).toBe(10);
+    expect(getRequestSplitParts(datasource, makeRequest(), config)).toBe(3);
   });
 
   it('does not split when disabled', () => {
@@ -52,10 +52,12 @@ describe('getRequestSplitParts', () => {
 
   it.each([
     [60, 1],
-    [5 * 60, 1],
-    [6 * 60, 2],
-    [12 * 60, 3],
-    [24 * 60, 4],
+    [24 * 60, 1],
+    [7 * 24 * 60, 1],
+    [30 * 24 * 60, 1],
+    [31 * 24 * 60, 2],
+    [60 * 24 * 60, 2],
+    [90 * 24 * 60, 3],
   ])('splits a range of %i minutes into %i parts', (minutes, parts) => {
     const to = dateTime(1700000000000);
     const from = dateTime(to.valueOf() - minutes * 60 * 1000);
@@ -108,7 +110,7 @@ describe('getRequestSplitParts', () => {
     const request = makeRequest({
       targets: [target({ refId: 'A', expr: 'up' }), target({ refId: 'B', expr: 'up', instant: true, hide: true })],
     });
-    expect(getRequestSplitParts(datasource, request, config)).toBe(10);
+    expect(getRequestSplitParts(datasource, request, config)).toBe(3);
   });
 });
 

--- a/public/app/features/query/state/streaming/splitQuery.ts
+++ b/public/app/features/query/state/streaming/splitQuery.ts
@@ -15,7 +15,7 @@ import { backendSrv } from 'app/core/services/backend_srv';
 
 import { QueryStreamingConfig, getQueryStreamingConfig } from './config';
 import { mergeChunkFrames } from './mergeFrames';
-import { calculateStreamingParts, splitTimeRangeDescending } from './timeSplitting';
+import { calculateStreamingParts, minutesToMs, splitTimeRangeDescending } from './timeSplitting';
 
 /** Runs a single (sub) request, provided by the caller to avoid a circular import with runRequest */
 export type QueryExecutor = (
@@ -25,9 +25,10 @@ export type QueryExecutor = (
 ) => Observable<DataQueryResponse>;
 
 /**
- * Decides how many parts a request should be split into. Returns 1 when the request must be run
- * as a single query (splitting disabled, not a supported panel/datasource, query not splittable
- * by time, or time range too short).
+ * Decides how many parts a request should be split into, so that no part covers more than the
+ * configured split interval. Returns 1 when the request must be run as a single query (splitting
+ * disabled, not a supported panel/datasource, query not splittable by time, or time range within
+ * the split interval).
  */
 export function getRequestSplitParts(
   datasource: DataSourceApi,
@@ -93,7 +94,7 @@ export function getRequestSplitParts(
   const fromMs = request.range.from.valueOf();
   const toMs = request.range.to.valueOf();
 
-  return calculateStreamingParts(toMs - fromMs, config.thresholds);
+  return calculateStreamingParts(toMs - fromMs, minutesToMs(config.splitIntervalMinutes));
 }
 
 /** Matches both `$__range`, `$__range_s`, `$__range_ms` and their `${...}` spelling */

--- a/public/app/features/query/state/streaming/timeSplitting.test.ts
+++ b/public/app/features/query/state/streaming/timeSplitting.test.ts
@@ -1,33 +1,29 @@
-import { DEFAULT_STREAMING_THRESHOLDS } from './config';
+import { DEFAULT_SPLIT_INTERVAL_MINUTES } from './config';
 import { calculateStreamingParts, minutesToMs, splitTimeRangeDescending } from './timeSplitting';
 
+const THIRTY_DAYS = minutesToMs(DEFAULT_SPLIT_INTERVAL_MINUTES);
+const DAY = minutesToMs(24 * 60);
+
 describe('calculateStreamingParts', () => {
-  it('does not split ranges shorter than 6 hours', () => {
-    expect(calculateStreamingParts(minutesToMs(359), DEFAULT_STREAMING_THRESHOLDS)).toBe(1);
-    expect(calculateStreamingParts(minutesToMs(60), DEFAULT_STREAMING_THRESHOLDS)).toBe(1);
-    expect(calculateStreamingParts(0, DEFAULT_STREAMING_THRESHOLDS)).toBe(1);
+  it('does not split ranges up to the split interval', () => {
+    expect(calculateStreamingParts(minutesToMs(60), THIRTY_DAYS)).toBe(1);
+    expect(calculateStreamingParts(7 * DAY, THIRTY_DAYS)).toBe(1);
+    expect(calculateStreamingParts(THIRTY_DAYS - 1, THIRTY_DAYS)).toBe(1);
+    expect(calculateStreamingParts(THIRTY_DAYS, THIRTY_DAYS)).toBe(1);
+    expect(calculateStreamingParts(0, THIRTY_DAYS)).toBe(1);
   });
 
-  it('picks the parts of the largest matching threshold', () => {
-    expect(calculateStreamingParts(minutesToMs(360), DEFAULT_STREAMING_THRESHOLDS)).toBe(2);
-    expect(calculateStreamingParts(minutesToMs(719), DEFAULT_STREAMING_THRESHOLDS)).toBe(2);
-    expect(calculateStreamingParts(minutesToMs(720), DEFAULT_STREAMING_THRESHOLDS)).toBe(3);
-    expect(calculateStreamingParts(minutesToMs(1440), DEFAULT_STREAMING_THRESHOLDS)).toBe(4);
-    expect(calculateStreamingParts(minutesToMs(2879), DEFAULT_STREAMING_THRESHOLDS)).toBe(4);
-    expect(calculateStreamingParts(minutesToMs(2880), DEFAULT_STREAMING_THRESHOLDS)).toBe(6);
-    expect(calculateStreamingParts(minutesToMs(4319), DEFAULT_STREAMING_THRESHOLDS)).toBe(6);
-    expect(calculateStreamingParts(minutesToMs(4320), DEFAULT_STREAMING_THRESHOLDS)).toBe(8);
-    expect(calculateStreamingParts(minutesToMs(10080), DEFAULT_STREAMING_THRESHOLDS)).toBe(10);
-    expect(calculateStreamingParts(minutesToMs(30 * 24 * 60), DEFAULT_STREAMING_THRESHOLDS)).toBe(10);
+  it('splits longer ranges into parts of at most the split interval', () => {
+    expect(calculateStreamingParts(THIRTY_DAYS + 1, THIRTY_DAYS)).toBe(2);
+    expect(calculateStreamingParts(45 * DAY, THIRTY_DAYS)).toBe(2);
+    expect(calculateStreamingParts(60 * DAY, THIRTY_DAYS)).toBe(2);
+    expect(calculateStreamingParts(90 * DAY, THIRTY_DAYS)).toBe(3);
+    expect(calculateStreamingParts(365 * DAY, THIRTY_DAYS)).toBe(13);
   });
 
-  it('does not depend on the order of the thresholds', () => {
-    const shuffled = [
-      { durationMinutes: 2880, parts: 6 },
-      { durationMinutes: 10080, parts: 10 },
-      { durationMinutes: 4320, parts: 8 },
-    ];
-    expect(calculateStreamingParts(minutesToMs(10080), shuffled)).toBe(10);
+  it('does not split when the interval is not usable', () => {
+    expect(calculateStreamingParts(90 * DAY, 0)).toBe(1);
+    expect(calculateStreamingParts(90 * DAY, -1)).toBe(1);
   });
 });
 

--- a/public/app/features/query/state/streaming/timeSplitting.ts
+++ b/public/app/features/query/state/streaming/timeSplitting.ts
@@ -1,5 +1,3 @@
-import { StreamingThreshold } from './config';
-
 export interface StreamingTimeRange {
   /** Start of the part (epoch ms) */
   fromMs: number;
@@ -16,24 +14,15 @@ export function minutesToMs(minutes: number): number {
 }
 
 /**
- * Number of parts a time range should be split into, based on its duration.
- * Ranges shorter than the smallest threshold are not split (1 part).
+ * Number of parts a time range should be split into, so that no part covers more than
+ * `splitIntervalMs`. Ranges up to the split interval are not split (1 part).
  */
-export function calculateStreamingParts(durationMs: number, thresholds: StreamingThreshold[]): number {
-  if (!(durationMs > 0)) {
+export function calculateStreamingParts(durationMs: number, splitIntervalMs: number): number {
+  if (!(durationMs > 0) || !(splitIntervalMs > 0) || durationMs <= splitIntervalMs) {
     return 1;
   }
 
-  // Check the largest threshold first
-  const sorted = [...thresholds].sort((a, b) => b.durationMinutes - a.durationMinutes);
-
-  for (const threshold of sorted) {
-    if (durationMs >= minutesToMs(threshold.durationMinutes)) {
-      return Math.max(1, Math.floor(threshold.parts));
-    }
-  }
-
-  return 1;
+  return Math.ceil(durationMs / splitIntervalMs);
 }
 
 export function roundDownToStep(timestampMs: number, stepMs: number): number {


### PR DESCRIPTION
Replaces the dynamic duration → parts thresholds in query splitting with a single fixed split interval.

- `streaming/config.ts`: `thresholds: StreamingThreshold[]` is replaced by `splitIntervalMinutes`, defaulting to `DEFAULT_SPLIT_INTERVAL_MINUTES = 30 * 24 * 60` (30d). The localStorage override now takes `{"splitIntervalMinutes": N}`; `StreamingThreshold`, `DEFAULT_STREAMING_THRESHOLDS` and `isThresholdArray` are gone.
- `streaming/timeSplitting.ts`: `calculateStreamingParts(durationMs, splitIntervalMs)` returns 1 for anything up to the interval, otherwise `ceil(duration / interval)`.
- `streaming/splitQuery.ts`: passes `minutesToMs(config.splitIntervalMinutes)`.

Behaviour: ≤ 30d runs as a single request (previously anything ≥ 6h was split), 31d → 2 parts, 60d → 2, 90d → 3, 1y → 13.

Note: `splitTimeRangeDescending` still divides the range into *equal* parts, so 30d is a cap rather than a literal chunk size — 90d is 3×30d, but 45d comes out as 2×22.5d rather than 30d + 15d. This avoids a degenerate tiny last chunk and keeps the first (newest, rendered first) chunk cheap.

## Tests

Threshold based tests were rewritten around the split interval, and the base fixtures in `splitQuery.test.ts` / `runRequestSplitting.test.ts` moved from 8d to 90d / 120d since 8d no longer splits.

`yarn jest public/app/features/query/state/streaming` — 52 tests, all passing. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)